### PR TITLE
Add history.ResetPointer

### DIFF
--- a/history/history.go
+++ b/history/history.go
@@ -68,7 +68,7 @@ func KeyFuncHistoryDown(this *readline.Buffer) readline.Result {
 
 func Push(input string) {
 	histories = append(histories, input)
-	pointor = len(histories)
+	ResetPointer();
 }
 
 func Replace(line string) (string, bool) {
@@ -204,6 +204,11 @@ func Replace(line string) (string, bool) {
 			buffer.WriteRune(ch)
 		}
 	}
+
+	if isReplaced {
+		ResetPointer();
+	}
+
 	return buffer.String(), isReplaced
 }
 
@@ -340,4 +345,8 @@ func Load(path string) error {
 		histories = append(histories, sc.Text())
 	}
 	return nil
+}
+
+func ResetPointer() {
+	pointor = len(histories)
 }

--- a/nyagos.go
+++ b/nyagos.go
@@ -153,6 +153,7 @@ func main() {
 			fmt.Fprintln(os.Stdout, line)
 		}
 		if line == "" {
+			history.ResetPointer();
 			continue
 		}
 		if line != history.LastHistory() {


### PR DESCRIPTION
1. history.ResetPointer関数追加
2. history.Replaceの時もhistoryのサーチポインタ位置がリセットされるよう修正
3. `INTR`で入力キャンセル時にサーチポインタ位置初期化(nyaos, tcsh互換)

あと、PRには含んでませんが
:o:pointer
:x:pointor
ではないでしょうか？
