### PR TITLE
Fix history.ResetPointer

### DIFF
--- a/history/history.go
+++ b/history/history.go
@@ -204,11 +204,6 @@ func Replace(line string) (string, bool) {
 			buffer.WriteRune(ch)
 		}
 	}
-
-	if isReplaced {
-		ResetPointer()
-	}
-
 	return buffer.String(), isReplaced
 }
 

--- a/nyagos.go
+++ b/nyagos.go
@@ -161,6 +161,8 @@ func main() {
 				fmt.Fprintln(fd, line)
 				fd.Close()
 			}
+		} else {
+			history.ResetPointer()
 		}
 
 		stackPos := L.GetTop()


### PR DESCRIPTION
- ヒストリ末尾のコマンドを<UP>キーで選択し実行した場合、ヒストリのポインタがリセットされない不具合修正
- 不要なResetPointer呼び出しを削除

先日のPR https://github.com/nocd5/nyagos/commit/a5b1efbed9687c975258a77426096ee1b4d348b6 での不備の修正です。
申し訳ありませんがよろしくお願いします。
