### PR TITLE
Fix path completion behavior with SLASH but no BACKSLASH.

### DIFF
--- a/completion/completion.go
+++ b/completion/completion.go
@@ -140,7 +140,7 @@ func KeyFuncCompletion(this *conio.Buffer) conio.Result {
 	slashToBackSlash := true
 	firstFoundSlashPos := strings.IndexRune(comp.Word, '/')
 	firstFoundBackSlashPos := strings.IndexRune(comp.Word, '\\')
-	if firstFoundSlashPos >= 0 && firstFoundBackSlashPos >= 0 && firstFoundSlashPos < firstFoundBackSlashPos {
+	if firstFoundSlashPos >= 0 && (firstFoundBackSlashPos == -1 || firstFoundSlashPos < firstFoundBackSlashPos) {
 		slashToBackSlash = false
 	}
 


### PR DESCRIPTION
パス補完時に、`/`はあるが`\`ない場合
入力済みの`/`も`\`に置換され補完されます。

例えば、
```
$ cd /Win<タブ>
```
で補完した場合、補完結果が
```
$ cd \Windows\
```
となります。

期待動作としては、最初に`/`があるので
補完結果は
```
$ cd /Windows/
```
ではないでしょうか？