### PR TITLE
Unix コマンドの unset に対応する操作を追加

### DIFF
--- a/commands/set.go
+++ b/commands/set.go
@@ -20,7 +20,11 @@ func cmd_set(cmd *interpreter.Interpreter) (interpreter.NextT, error) {
 		if eqlPos < 0 {
 			fmt.Fprintf(cmd.Stdout, "%s=%s\n", arg, os.Getenv(arg))
 		} else {
-			os.Setenv(arg[:eqlPos], arg[eqlPos+1:])
+			if eqlPos + 1 < len(arg) {
+				os.Setenv(arg[:eqlPos], arg[eqlPos+1:])
+			} else {
+				os.Unsetenv(arg[:eqlPos])
+			}
 		}
 	}
 	return interpreter.CONTINUE, nil

--- a/main/lua_cmd.go
+++ b/main/lua_cmd.go
@@ -49,7 +49,11 @@ func cmdSetEnv(L *lua.Lua) int {
 	if valueErr != nil {
 		return L.Push(nil, valueErr)
 	}
-	os.Setenv(name, value)
+	if len(value) > 0 {
+		os.Setenv(name, value)
+	} else {
+		os.Unsetenv(name)
+	}
 	return L.Push(true)
 }
 


### PR DESCRIPTION
環境変数の削除する方法が提供されていなかったので、実装してみました。

`$ unset name` としようとしたのですが、Windows のコマンドプロンプトでは、`$ set name=` とすると削除されるようなので、そのように実装しました。

```sh
$ set name= # これで消える
$ lua_e "nyagos.setenv('name', '')" # これでも消える
```

実装方法に問題などあれば、修正します。よろしくお願いいたします。