### PR TITLE
Fix typographical error(s)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Programming Language GO and Lua.
   * Alias
   * Filename/Command-name completion
 * Support UNICODE
-  * Can paste unicode charactor on clipboard and edit them.
+  * Can paste unicode character on clipboard and edit them.
   * Unicode-literal %U+XXXX%
   * Prompt Macro $Uxxxx
 * Built-in ls


### PR DESCRIPTION
@zetamatta, I've corrected a typographical error in the documentation of the [nyagos](https://github.com/zetamatta/nyagos) project. Specifically, I've changed charactor to character. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.