### PR TITLE
add 2nd subcommand completion

### DIFF
--- a/nyagos.d/catalog/subcomplete.lua
+++ b/nyagos.d/catalog/subcomplete.lua
@@ -59,6 +59,19 @@ if next(share.maincmds) then
         if not cmdname then
             return nil
         end
+        --[[
+          2nd command completion like :git bisect go[od]
+          user define-able
+
+          local subcommands={"good", "bad"}
+          local maincmds=share.maincmds
+          maincmds["git bisect"] = subcommands
+          share.maincmds = maincmds
+        --]]
+        local cmd2nd = string.match(c.text,"^%S+%s+%S+")
+        if share.maincmds[cmd2nd] then
+          cmdname = cmd2nd
+        end
         local subcmds = share.maincmds[cmdname]
         if not subcmds then
             return nil


### PR DESCRIPTION
#205 support

use this
subcommand completion from git-completion.bash

```:lua
-- in user .nyagos
-- catalog
use "subcomplete"

-- completion 2nd append start
local maincmds = share.maincmds
-- git
local gitsubcommands={}
-- setup
gitsubcommands["bisect"]={"start", "bad", "good", "skip", "reset", "visualize", "replay", "log", "run"}
gitsubcommands["notes"]={"add", "append", "copy", "edit", "list", "prune", "remove", "show"}
gitsubcommands["reflog"]={"show", "delete", "expire"}
gitsubcommands["rerere"]={"clear", "forget", "diff", "remaining", "status", "gc"}
gitsubcommands["stash"]={"save", "list", "show", "apply", "clear", "drop", "pop", "create", "branch"}
gitsubcommands["submodule"]={"add", "status", "init", "deinit", "update", "summary", "foreach", "sync"}
gitsubcommands["svn"]={"init", "fetch", "clone", "rebase", "dcommit", "log", "find-rev", "set-tree", "commit-diff", "info", "create-ignore", "propget", "proplist", "show-ignore", "show-externals", "branch", "tag", "blame", "migrate", "mkdirs", "reset", "gc"}
gitsubcommands["worktree"]={"add", "list", "lock", "prune", "unlock"}

-- build
for key, cmds in pairs(gitsubcommands) do
  local gitcommand="git "..key
  maincmds[gitcommand]=cmds
end

-- replace
share.maincmds = maincmds
-- completion 2nd append end
```
