### PR TITLE
Fix git branch func registration

### DIFF
--- a/nyagos.d/catalog/git.lua
+++ b/nyagos.d/catalog/git.lua
@@ -28,8 +28,10 @@ gitsubcommands["reset"]=branchdetect
 gitsubcommands["merge"]=branchdetect
 gitsubcommands["rebase"]=branchdetect
 
-share.git.subcommand=gitsubcommands
-share.git.branch = branchdetect
+local gitvar=share.git
+gitvar.subcommand=gitsubcommands
+gitvar.branch=branchdetect
+share.git=gitvar
 
 if share.maincmds then
   if share.maincmds["git"] then


### PR DESCRIPTION
関数のshareへの登録と動作の確認をしましたので、修正をpullします。

以下としてaliasで関数補完ができています(coはcheckoutの短縮、mbはmergeの短縮)

```lua:.nyagos
use "git"

-- completion 2nd append start
local maincmds = share.maincmds
-- git
local gitsubcommands={}
-- setup
-- alias
gitsubcommands["co"]=share.git.branch
gitsubcommands["mb"]=share.git.branch

-- build
for key, cmds in pairs(gitsubcommands) do
  local gitcommand="git "..key
  maincmds[gitcommand]=cmds
end
-- replace
share.maincmds = maincmds
-- completion 2nd append end
```