### PR TITLE
Fix: aliasandset.lua

### DIFF
--- a/nyagos.d/aliasandset.lua
+++ b/nyagos.d/aliasandset.lua
@@ -32,7 +32,7 @@ function set(equation)
     set_(nyagos.setenv,equation,expand)
 end
 function alias(equation)
-    set_(nyagos.alias,equation,function(x) return x end)
+    set_(nyagos.setalias,equation,function(x) return x end)
 end
 function addpath(...)
     for _,dir in pairs{...} do


### PR DESCRIPTION
4.1.9.2以降で`alias`の定義でエラーが発生していたので修正してみました
```lua
alias { e = 'vim' }
```
```
[string "C:\nyagos-4.1.9_3-amd64\nyagos.d\aliasandset...."]:11: attempt to call a userdata value (local 'f')
```