### PR TITLE
Fix: autocd.lua

### DIFF
--- a/nyagos.d/catalog/autocd.lua
+++ b/nyagos.d/catalog/autocd.lua
@@ -6,6 +6,9 @@ nyagos.argsfilter = function(args)
       args = args_
     end
   end
+  if nyagos.which(args[0]) then
+    return
+  end
   local stat = nyagos.stat(args[0])
   if not stat or not stat.isdir then
     return


### PR DESCRIPTION
同名のフォルダとコマンドと存在する際にフォルダが優先されて(例:`~/go`と`go.exe`)
bash等のautocdではコマンドが優先、と挙動が違ったので修正しました