### PR TITLE
fix ANSI escape code for cursor backward

### DIFF
--- a/readline/buffer.go
+++ b/readline/buffer.go
@@ -41,7 +41,7 @@ func PutRunes(ch rune, n int) {
 
 func Backspace(n int) {
 	if n > 1 {
-		fmt.Fprintf(Console, "\x1B[%dC", n)
+		fmt.Fprintf(Console, "\x1B[%dD", n)
 	} else if n == 1 {
 		fmt.Fprint(Console, "\b")
 	}


### PR DESCRIPTION
related https://github.com/mattn/go-colorable/commit/3fa8c76f

上記コミット以降の go-colorable に対応するための修正です。
逆に go-colorable が上記コミットより前の状態でビルドすると、Ctrl-A 等でカーソルを移動した時に意図と逆方向にカーソルが移動します。