### PR TITLE
completion_hook の戻り値の配列の順序が保持されない

### DIFF
--- a/mains/complete_lua.go
+++ b/mains/complete_lua.go
@@ -39,12 +39,14 @@ func luaHookForComplete(this *readline.Buffer, rv *completion.List) (*completion
 			if t, ok := result.(map[interface{}]interface{}); ok {
 				list := make([]completion.Element, 0, len(rv.List)+32)
 				wordUpr := strings.ToUpper(rv.Word)
-				for _, v := range t {
-					str, ok := v.(string)
-					if ok {
-						strUpr := strings.ToUpper(str)
-						if strings.HasPrefix(strUpr, wordUpr) {
-							list = append(list, completion.Element{InsertStr: str, ListupStr: str})
+				for i := 0; i < len(t); i++ {
+					if v, ok := t[i+1]; ok {
+						str, ok := v.(string)
+						if ok {
+							strUpr := strings.ToUpper(str)
+							if strings.HasPrefix(strUpr, wordUpr) {
+								list = append(list, completion.Element{InsertStr: str, ListupStr: str})
+							}
 						}
 					}
 				}


### PR DESCRIPTION
completion_hook で補完候補をカスタマイズできますが、戻り値として返した配列の順序が保存されないようです。

例えば、
```lua
nyagos.completion_hook = function(c)
    -- case-sensitive completion.
    local list = {"aa", "ab", "ac", "ad"}
    return list
end
```
という completion_hook を指定し、
```bash
> a[TAB]
```
を実行した場合、表示される `aa ab ac ad` の順序が TAB を押すたびに変わります。

Lua での配列は Go の世界に戻った時に map になるので、そこで要素の順序が保証されなくなっているように見えました。

(Go も Lua も初心者なので、変な個所がありましたらご指摘いただけると助かります。)