### PR TITLE
Reject conversion from userdata to Object.

### DIFF
--- a/lua/to.go
+++ b/lua/to.go
@@ -317,10 +317,7 @@ func (this Lua) ToObject(index int) (Object, error) {
 		result, err = this.ToTable(index)
 		seek_metatable = true
 	case LUA_TUSERDATA:
-		size := this.RawLen(index)
-		ptr := this.ToUserData(index)
-		result = TFullUserData(CGoBytes(uintptr(ptr), uintptr(size)))
-		seek_metatable = true
+		return nil, errors.New("lua.ToSomeThing: LUA_TUSRDATA is not supported.")
 	default:
 		return nil, errors.New("lua.ToSomeThing: Not supported type found.")
 	}


### PR DESCRIPTION

Most of `userdata` should not be set to `share` hash.

Let's think of the following example.

```lua
-- Create WScript.Shell.
local ole = nyagos.create_object("WScript.Shell")

-- Launch notepad.exe
-- This will launch notepad.exe successfully.
ole:Run("notepad.exe")

for i=1, 10 do
    -- Save ole in share hash.
    share.ole = ole
    ole = nil

    -- The following ensures that ole object is garbage-collected.
    -- As a result, ole:__gc is called.
    collectgarbage("collect")

    -- Retrieve ole from share hash.
    ole = share.ole
end

-- The following may fail and cause crash because ole:__gc has been called and 
-- `Data *ole.IDispatch` in capsule_t has already been released.
ole:Run("notepad.exe")
```

In the above example, the second call of `ole:Run` may fail because `ole:__gc` has already been called and `Data` in `capsule_t` has been released.

In general, setting `userdata` object to `share` hash causes this kind of issue because Lua VM cannot manage members in `share` hash.  
Therefore, it may cause duplicated call of `__gc` and other unexpected behaviors.

To avoid this kind of issues, this patch always rejects conversion from `userdata` in Lua to Object in Golang.

This patch may affect existing Lua scripts, which store `userdata` to `share` hash, such as `capture_t`, `method_t`, `iolines_t`, `stream_t` and so on although this patch solves the issue.