### PR TITLE
Keep userdata objects in Golang world to avoid garbage collection.

### DIFF
--- a/lua/meta.go
+++ b/lua/meta.go
@@ -40,9 +40,5 @@ func (this Lua) TestUDataTo(index int, tname string, p interface{}) (func(), err
 	if src == 0 {
 		return noOperation, ErrTestUData
 	}
-	dst, siz := PtrAndSize(p)
-	copyMemory(dst, src, siz)
-	return func() {
-		copyMemory(src, dst, siz)
-	}, nil
+	return this.ToUserDataTo(index, p), nil
 }

--- a/lua/ole/ole.go
+++ b/lua/ole/ole.go
@@ -32,6 +32,7 @@ func (this capsule_t) Push(L lua.Lua) int {
 }
 
 func gc(L lua.Lua) int {
+	defer L.DeleteUserDataAnchor(1)
 	p := capsule_t{}
 	sync := L.ToUserDataTo(1, &p)
 	defer sync()
@@ -182,6 +183,7 @@ func index(L lua.Lua) int {
 		L.NewMetaTable(METHOD_T)
 		L.PushGoFunction(call2)
 		L.SetField(-2, "__call")
+		L.SetGcFunctionForUserData(-2, -1)
 		L.SetMetaTable(-2)
 		return 1
 	}

--- a/lua/stream.go
+++ b/lua/stream.go
@@ -12,7 +12,7 @@ type stream_t struct {
 }
 
 func (this Lua) pushStream(fd ansicfile.FilePtr, closer func(Lua) int) {
-	this.PushUserData(&stream_t{
+	this.PushRawUserData(&stream_t{
 		FilePtr: fd,
 		Closer:  syscall.NewCallbackCDecl(closer),
 	})
@@ -22,7 +22,7 @@ func (this Lua) pushStream(fd ansicfile.FilePtr, closer func(Lua) int) {
 
 func closer(this Lua) int {
 	userdata := stream_t{}
-	this.ToUserDataTo(1, &userdata)
+	this.ToRawUserDataTo(1, &userdata)
 	userdata.FilePtr.Close()
 	// print("stream_closed\n")
 	return 0

--- a/mains/lua_cmd.go
+++ b/mains/lua_cmd.go
@@ -714,6 +714,7 @@ func (this *iolines_t) Ok() bool {
 }
 
 func iolines_t_gc(L lua.Lua) int {
+	defer L.DeleteUserDataAnchor(1)
 	userdata := iolines_t{}
 	sync := L.ToUserDataTo(1, &userdata)
 	defer sync()
@@ -816,6 +817,10 @@ func cmdLines(L lua.Lua) int {
 			HasToClose: false,
 			Marks:      []string{"l"},
 		})
+		L.NewTable()
+		L.Push(iolines_t_gc)
+		L.SetField(-2, "__gc")
+		L.SetMetaTable(-2)
 		return 2
 	}
 	path, path_err := L.ToString(1)


### PR DESCRIPTION
## Steps to reproduce the issue

The following `sample.lua` sometimes causes panic.

```lua
-- sample.lua
for i = 1, 10000 do
    for line in nyagos.lines("sample.lua") do
    end
end
```

Run the above script as follows:
```bat
C:\Users\xxx> set GOGC=1
C:\Users\xxx> nyagos.exe
Nihongo Yet Another GOing Shell 4.2.1_0-7-g6412fc0-386 by go1.8.3 & Lua 5.3
(c) 2014-2017 NYAOS.ORG <http://www.nyaos.org>
$ lua_f sample.lua
```

Here is the output of panic.
```
runtime: nelems=1024 nfree=1019 nalloc=5 previous allocCount=4 nfreed=65535
fatal error: sweep increased allocation count

runtime stack:
runtime.throw(0x5a0549, 0x20)
        C:/my_program/go/src/runtime/panic.go:596 +0x7c
runtime.(*mspan).sweep(0x9d67e4, 0x300, 0x3f3)
        C:/my_program/go/src/runtime/mgcsweep.go:288 +0x694
runtime.sweepone(0x42ab6c)
        C:/my_program/go/src/runtime/mgcsweep.go:110 +0x1ac
runtime.gosweepone.func1()
        C:/my_program/go/src/runtime/mgcsweep.go:125 +0x21
runtime.systemstack(0x10d09500)
        C:/my_program/go/src/runtime/asm_386.s:337 +0x5e
runtime.mstart()
        C:/my_program/go/src/runtime/proc.go:1132

goroutine 3 [running]:
runtime.systemstack_switch()
        C:/my_program/go/src/runtime/asm_386.s:291 fp=0x10d13fb8 sp=0x10d13fb4
runtime.gosweepone(0x0)
        C:/my_program/go/src/runtime/mgcsweep.go:126 +0x43 fp=0x10d13fcc sp=0x10d13fb8
runtime.bgsweep(0x10cf81c0)
        C:/my_program/go/src/runtime/mgcsweep.go:59 +0xa7 fp=0x10d13fe8 sp=0x10d13fcc
runtime.goexit()
        C:/my_program/go/src/runtime/asm_386.s:1629 +0x1 fp=0x10d13fec sp=0x10d13fe8
created by runtime.gcenable
        C:/my_program/go/src/runtime/mgc.go:212 +0x55

goroutine 1 [running, locked to thread]:
        goroutine running on other thread; stack unavailable

goroutine 17 [syscall]:
os/signal.signal_recv(0x0)
        C:/my_program/go/src/runtime/sigqueue.go:116 +0x14f
os/signal.loop()
        C:/my_program/go/src/os/signal/signal_unix.go:22 +0x1a
created by os/signal.init.1
        C:/my_program/go/src/os/signal/signal_unix.go:28 +0x37

goroutine 18 [chan receive]:
github.com/zetamatta/go-getch.(*Handle).ctrlCHandler(0x10cfc2e0, 0x10cf8440)
        C:/work/git_repos/src/github.com/zetamatta/go-getch/ctrlc.go:9 +0x47
created by github.com/zetamatta/go-getch.(*Handle).DisableCtrlC
        C:/work/git_repos/src/github.com/zetamatta/go-getch/ctrlc.go:34 +0xa9

goroutine 19 [select]:
github.com/zetamatta/nyagos/shell.(*Cmd).Loop.func1(0x10cf8a40, 0x10cf8a00, 0x10cf8a40, 0x10ec64a0)
        C:/work/git_repos/src/github.com/zetamatta/nyagos/shell/loop.go:35 +0xaa
created by github.com/zetamatta/nyagos/shell.(*Cmd).Loop
        C:/work/git_repos/src/github.com/zetamatta/nyagos/shell/loop.go:45 +0x1ab
exit status 2
```

## Details

This is caused by unexpected garbage collection for `userdata`.

To resolve this issue, I propose to use `userdataAnchor` and other variables to keep `userdata` in Golang world.

Here is the overview of the handling of `userdata`.

1. In `PushUserData`, copy an object pointed by `p interface{}` to heap.
2. Store the address of the object to `userdata`.
3. Keep the object in `userdataAnchor` to avoid garbage collection.

On the other hand, this patch needs to call `DeleteUserDataAnchor` in `__gc` to release the object.

## Handling of `stream_t`

It seems that `stream_t` is compatible with `luaL_Stream`, so I implemented `PushRawUserData` to handle this type of object.

The function, `PushRawUserData`, does not register the object in `userdataAnchor`, so it is not managed by Golang GC.
