### PR TITLE
Fix crash in cmd_bindkey.

### DIFF
--- a/commands/bindkey.go
+++ b/commands/bindkey.go
@@ -12,6 +12,7 @@ func cmd_bindkey(ctx context.Context, cmd *shell.Cmd) (int, error) {
 	if len(cmd.Args) < 3 {
 		fmt.Fprintf(cmd.Stderr, "%[1]s: Usage %[1]s KEYNAME FUNCNAME\n",
 			cmd.Args[0])
+		return 0, nil
 	}
 	err := readline.BindKeySymbol(cmd.Args[1], cmd.Args[2])
 	if err != nil {


### PR DESCRIPTION
This patch fixes crash in `cmd_bindkey`.

When `bindkey` is called without any arguments, it causes crash of NYAGOS.

Regards,
Murase