### PR TITLE
Topic/gitlua encode fix

### DIFF
--- a/nyagos.d/catalog/git.lua
+++ b/nyagos.d/catalog/git.lua
@@ -22,6 +22,7 @@ end
 
 -- subcommands
 local gitsubcommands={}
+
 -- keyword
 gitsubcommands["bisect"]={"start", "bad", "good", "skip", "reset", "visualize", "replay", "log", "run"}
 gitsubcommands["notes"]={"add", "append", "copy", "edit", "list", "prune", "remove", "show"}
@@ -59,3 +60,5 @@ if share.maincmds then
     share.maincmds = maincmds
   end
 end
+
+-- EOF


### PR DESCRIPTION
以前色々git.luaへコミットしましたが、リポジトリ内の改行コードがLFになっていました
(リリースファイルの中でgit.luaだけ別になった状態だった)

このリポジトリではCRLF格納なようなので、コメント類の微修正とともにCRLFで格納しなおしました