### PR TITLE
Fix issue that user's .nyagos was not loaded

### DIFF
--- a/frame/loadscr.go
+++ b/frame/loadscr.go
@@ -70,7 +70,8 @@ func dotNyagos(langEngine func(string) ([]byte, error)) error {
 	}
 	cachePath := filepath.Join(AppDataDir(), runtime.GOARCH+".nyagos.luac")
 	cacheStat, err := os.Stat(cachePath)
-	if err == nil && !dotStat.ModTime().After(cacheStat.ModTime()) {
+	if err == nil && cacheStat.Size() != 0 &&
+		!dotStat.ModTime().After(cacheStat.ModTime()) {
 		_, err = langEngine(cachePath)
 		return err
 	}
@@ -78,7 +79,11 @@ func dotNyagos(langEngine func(string) ([]byte, error)) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(cachePath, chank, os.FileMode(0644))
+	if chank != nil {
+		return ioutil.WriteFile(cachePath, chank, os.FileMode(0644))
+	} else {
+		return nil
+	}
 }
 
 func barNyagos(shellEngine func(string) error, folder string) {


### PR DESCRIPTION
多分[ここ](https://github.com/zetamatta/nyagos/blob/master/gopherSh/nyagos.go#L103)で`nil`を返しているためだと思いますが、キャッシュが空になり2回目の起動時から`%HOME%\.nyagos`または`%USERPROFILE\.nyagos`の内容が読み込まれません。`chank != nil` の場合のみ書き込むようにするだけでも良いかと思いますが、既に`0Byte`のキャッシュができている場合の救済策として空の場合はキャッシュを読まないようにしています。