### PR TITLE
Change to delete if .nyagos cache is invalid

### DIFF
--- a/frame/loadscr.go
+++ b/frame/loadscr.go
@@ -70,20 +70,20 @@ func dotNyagos(langEngine func(string) ([]byte, error)) error {
 	}
 	cachePath := filepath.Join(AppDataDir(), runtime.GOARCH+".nyagos.luac")
 	cacheStat, err := os.Stat(cachePath)
-	if err == nil && cacheStat.Size() != 0 &&
-		!dotStat.ModTime().After(cacheStat.ModTime()) {
-		_, err = langEngine(cachePath)
-		return err
+	if err == nil {
+		if cacheStat.Size() != 0 && !dotStat.ModTime().After(cacheStat.ModTime()) {
+			_, err = langEngine(cachePath)
+			if err == nil {
+				return nil
+			}
+		}
+		os.Remove(cachePath)
 	}
 	chank, err := langEngine(dot_nyagos)
-	if err != nil {
+	if err != nil || chank == nil {
 		return err
 	}
-	if chank != nil {
-		return ioutil.WriteFile(cachePath, chank, os.FileMode(0644))
-	} else {
-		return nil
-	}
+	return ioutil.WriteFile(cachePath, chank, os.FileMode(0644))
 }
 
 func barNyagos(shellEngine func(string) error, folder string) {


### PR DESCRIPTION
#305 については早々に対応頂いてありがとうございました。`lua53.dll`版から`Gopher-Lua `版にアップデートした場合、`.nyagos`のキャッシュが読み込めず`%HOME%\.nyagos`または`%USERPROFILE%\.nyagos`の読み込みに失敗します。Luaの実装が変わったことの検出方法が不明で、手で消せば良いやということで、 #305 では対応できなかったのですが、よく考えてみればキャッシュの読み込みに失敗した(キャッシュが無効だった)場合、キャッシュを消してしまって問題ないことに気づきました。その方向で修正してみたのですが、問題なければ取り込んで頂けますか。