### PR TITLE
Modify document to fix  clone destination directory

### DIFF
--- a/Doc/09-Build_en.md
+++ b/Doc/09-Build_en.md
@@ -26,8 +26,8 @@ They are able to be downloaded with `make.cmd get`.
 
 On `%GOPATH%` folder,
 
-    git clone https://github.com/zetamatta/nyagos nyagos
-    cd nyagos
+    git clone https://github.com/zetamatta/nyagos src/github.com/zetamatta/nyagos
+    cd src/github.com/zetamatta/nyagos
 
 (for stable version)
 

--- a/Doc/09-Build_ja.md
+++ b/Doc/09-Build_ja.md
@@ -26,13 +26,15 @@
 
 `%GOPATH%` にて
 
-    git clone https://github.com/zetamatta/nyagos nyagos
-    cd nyagos
+    git clone https://github.com/zetamatta/nyagos src/github.com/zetamatta/nyagos
+    cd src/github.com/zetamatta/nyagos
 
 (安定板の時)
+
     git checkout master
 
 (最新版の時)
+
     git checkout develop
 
     make.cmd get


### PR DESCRIPTION
`%GOPATH%/src/github.com/zetamatta/nyagos`にクローンしないと、`%GOPATH%/nyagos/dos/zsyscall.go`が生成されずビルドに失敗するためにドキュメントを修正しました。