### PR TITLE
no install goversioninfo.exe to $GOPATH/bin

### DIFF
--- a/make.cmd
+++ b/make.cmd
@@ -205,8 +205,8 @@ function Download-Exe($url,$exename){
         return
     }
     Write-Verbose -Message ("{0} not found." -f $exename)
-    Write-Verbose -Message ("$ $GO get " + $url)
-    & $GO get $url
+    Write-Verbose -Message ("$ $GO get -d " + $url)
+    & $GO get -d $url
     $workdir = (Join-Path (Join-Path (Get-Go1stPath) "src") $url)
     $cwd = (Get-Location)
     Set-Location $workdir


### PR DESCRIPTION
make.cmd で goversioninfo.exe を生成する際に $GOPATH/bin に goversioninfo.exe をインストールすることは意図してなさそうだったので、go get の -d フラグでダウンロードのみにする PR です。

go get 後に goversioninfo 側で go build したものをコピーしてきてるところから上記のように読んだのですが、そもそも前提が間違っていましたら破棄してください 🙇