### PR TITLE
Fix Lua's file:read

### DIFF
--- a/mains/io.go
+++ b/mains/io.go
@@ -317,6 +317,10 @@ func fileRead(L *lua.LState) int {
 		if f, ok := ud.Value.(*ioLuaReader); ok {
 			r := f.reader
 			end := L.GetTop()
+			if end == 1 {
+				L.Push(lua.LString("*l"))
+				end++
+			}
 			result := make([]lua.LValue, 0, end-1)
 			for i := 2; i <= end; i++ {
 				val := L.Get(i)
@@ -336,7 +340,7 @@ func fileRead(L *lua.LState) int {
 					switch s {
 					case "*l":
 						line, err := r.ReadString('\n')
-						if err != nil {
+						if (err != nil && err != io.EOF) || (err == io.EOF && line == "") {
 							return lerror(L, err.Error())
 						}
 						line = strings.TrimSuffix(line, "\n")


### PR DESCRIPTION
4.3.2_0 から `io.*` が NYAGOS の自前バージョンに置き変えられましたが、`file:read(...)` に以下のような問題があるようです。

- フォーマットを省略した場合、デフォルトで `*l` になるべきところがそうなっていないようです
- フォーマットが `*l` の場合、かつ行が改行で終わっていない場合に何も読み取られないようです

修正してみましたので、問題がなければ取り込んで頂けますか？