### PR TITLE
Fix shell.readEnv

### DIFF
--- a/shell/source.go
+++ b/shell/source.go
@@ -29,7 +29,9 @@ func readEnv(scan *bufio.Scanner, verbose io.Writer) (int, error) {
 			if left == "ERRORLEVEL_" {
 				value, err := strconv.ParseUint(right, 10, 32)
 				if err != nil {
-					fmt.Fprintf(verbose, "Could not read ERRORLEVEL(%s)\n", right)
+					if verbose != nil {
+						fmt.Fprintf(verbose, "Could not read ERRORLEVEL(%s)\n", right)
+					}
 				} else {
 					errorlevel = int(value)
 				}


### PR DESCRIPTION
*.cmd ファイル等を実行した際にnyagosが異常終了するため対応してみました。

例) 以下のファイルを実行するとnyagosが異常終了します。

test.cmd
```cmd
exit /b -1
```

nyagos.dump
```
************ Panic Occurred. ***********
runtime error: invalid memory address or nil pointer dereference
goroutine 1 [running]:
runtime/debug.Stack(0x6d5300, 0xc00021c0a0, 0xc0002c3490)
	C:/Go/src/runtime/debug/stack.go:24 +0xae
github.com/zetamatta/nyagos/frame.PanicHandler()
	C:/home/go/src/github.com/zetamatta/nyagos/frame/misc.go:52 +0x1b4
panic(0x64e2c0, 0x860600)
	C:/Go/src/runtime/panic.go:513 +0x1c7
fmt.Fprintf(0x0, 0x0, 0x694b62, 0x1e, 0xc0002c3718, 0x1, 0x1, 0x0, 0x0, 0xc0002c3748)
	C:/Go/src/fmt/print.go:189 +0x7e
github.com/zetamatta/nyagos/shell.readEnv(0xc0002c3790, 0x0, 0x0, 0x0, 0x0, 0x42b00a)
	C:/home/go/src/github.com/zetamatta/nyagos/shell/source.go:32 +0x402
github.com/zetamatta/nyagos/shell.loadTmpFile(0xc000348e80, 0x32, 0x0, 0x0, 0x0, 0x0, 0x0)
	C:/home/go/src/github.com/zetamatta/nyagos/shell/source.go:82 +0x1bd
github.com/zetamatta/nyagos/shell.RawSource(0xc0003ef970, 0x1, 0x1, 0x0, 0x0, 0x0, 0x6d5340, 0xc000080000, 0x6d53a0, 0xc000080008, ...)
	C:/home/go/src/github.com/zetamatta/nyagos/shell/source.go:176 +0x39c
github.com/zetamatta/nyagos/shell.(*Cmd).spawnvpSilent(0xc0002d2000, 0x6d6480, 0xc0004b0420, 0x52fd80, 0xc0003b6f48, 0x8)
	C:/home/go/src/github.com/zetamatta/nyagos/shell/interpreter.go:228 +0x32e
github.com/zetamatta/nyagos/shell.(*Cmd).Spawnvp(0xc0002d2000, 0x6d6480, 0xc0004b0420, 0xc0003ef5e0, 0x1, 0x1)
	C:/home/go/src/github.com/zetamatta/nyagos/shell/interpreter.go:268 +0x61
github.com/zetamatta/nyagos/shell.(*Shell).Interpret(0xc0000b0960, 0x6d6480, 0xc0004b0420, 0xc0003b6e80, 0x8, 0xc0003eec80, 0xc0004b0420, 0xc0003b6e80)
	C:/home/go/src/github.com/zetamatta/nyagos/shell/interpreter.go:385 +0x5a5
github.com/zetamatta/nyagos/shell.(*Shell).Loop(0xc0000b0960, 0x6d6480, 0xc0004b03f0, 0x6d5160, 0xc000358800, 0x66e760, 0xc0000b0001, 0xc0004b03f0)
	C:/home/go/src/github.com/zetamatta/nyagos/shell/loop.go:91 +0x245
github.com/zetamatta/nyagos/shell.(*Shell).ForEver(0xc0000b0960, 0x6d6480, 0xc0004b03f0, 0x6d5160, 0xc000358800)
	C:/home/go/src/github.com/zetamatta/nyagos/shell/loop.go:116 +0x6d
github.com/zetamatta/nyagos/mains.Main(0x0, 0x0)
	C:/home/go/src/github.com/zetamatta/nyagos/mains/nyagos.go:196 +0x5d9
github.com/zetamatta/nyagos/frame.Start(0x69c270, 0x0, 0x0)
	C:/home/go/src/github.com/zetamatta/nyagos/frame/misc.go:39 +0x159
main.main()
	C:/home/go/src/github.com/zetamatta/nyagos/main.go:19 +0x61
*** Please copy these error message ***
*** And hit ENTER key to quit.      ***
```