### PR TITLE
completion support hub like git

### DIFF
--- a/nyagos.d/catalog/git.lua
+++ b/nyagos.d/catalog/git.lua
@@ -3,6 +3,12 @@ if not nyagos then
     os.exit()
 end
 
+-- hub exists, replace git command
+local hubpath=nyagos.which("hub.exe")
+if hubpath then
+  nyagos.alias.git = "hub.exe"
+end
+
 share.git = {}
 
 -- setup local branch listup

--- a/nyagos.d/catalog/subcomplete.lua
+++ b/nyagos.d/catalog/subcomplete.lua
@@ -7,8 +7,33 @@ share.maincmds = {}
 
 -- git
 local githelp=io.popen("git help -a 2>nul","r")
+local hubhelp=io.popen("hub help -a 2>nul","r")
 if githelp then
     local gitcmds={}
+    local hub=false
+    if hubhelp then
+      hub=true
+      local startflag = false
+      local found=false
+      for line in hubhelp:lines() do
+        if not found then
+          if startflag then
+            -- skip blank line
+            if string.match(line,"%S") then
+              -- found commands
+              for word in string.gmatch(line, "%S+") do
+                gitcmds[ #gitcmds+1 ] = word
+              end
+              found = true
+            end
+          end
+          if string.match(line,"hub custom") then
+            startflag = true
+          end
+        end
+      end
+      hubhelp:close()
+    end
     for line in githelp:lines() do
         local word = string.match(line,"^ +(%S+)")
         if nil ~= word then
@@ -20,6 +45,10 @@ if githelp then
         local maincmds = share.maincmds
         maincmds["git"] = gitcmds
         maincmds["git.exe"] = gitcmds
+        if hub then
+          maincmds["hub"] = gitcmds
+          maincmds["hub.exe"] = gitcmds
+        end
         share.maincmds = maincmds
     end
 end


### PR DESCRIPTION
hubコマンドをサポートするPRです。

* hubコマンドがあれば、hubにも補完が発生+gitの補完にhubの特別コマンド追加
* hubコマンドがあるなら、gitのエイリアスに設定

GITHUB_TOKENを使って、`git issue`とかできます。

自分は環境変数にTOKEN載せたくないので、次のような設定にしましたが。

```lua:dot.nyagos.lua
-- hub command with github token
if nyagos.which("hub.exe") then
  nyagos.alias.hub = function(args)
    local github_secret = nyagos.eval('gpg --no-verbose --quiet --batch --decrypt --output - ~\\.password-store\\Develop\\Github.gpg 2> nul')
    github_secret = github_secret .. "\n" -- lastline append return
    local token = ""
    local username = ""
    for line in github_secret:gmatch("[^\r\n]+") do
      if (0 ~= string.len(token)) and (0 == string.len(username)) then
        username = line:match("^username:%s+(%S+)")
      end
      if 0 == string.len(token) then
        token = line
      end
    end
    nyagos.env["GITHUB_USER"] = username
    nyagos.env["GITHUB_TOKEN"] = token

    -- set hub.exe
    args[0] = "hub.exe"
    assert(nyagos.rawexec(args))
  end
  -- git call hub exe with wrapper function
  nyagos.alias.git = nyagos.alias.hub
end
```