### PR TITLE
Fix the file size output of `ls -h` to be displayed in units.

### DIFF
--- a/commands/ls_windows.go
+++ b/commands/ls_windows.go
@@ -135,7 +135,7 @@ func lsOneLong(folder string, status os.FileInfo, flag int, width int, out io.Wr
 		name = filepath.Base(name)
 	}
 	if (flag & O_HUMAN) != 0 {
-		fmt.Fprintf(out, " %*s", width, humanize.Comma(status.Size()))
+		fmt.Fprintf(out, " %*s", width, humanize.Bytes(uint64(status.Size())))
 	} else {
 		fmt.Fprintf(out, " %*d", width, status.Size())
 	}


### PR DESCRIPTION
`ls -h` オプションが仕様と違ってカンマ区切りになっています。

nyagos 4.4.6_2

https://github.com/zetamatta/nyagos/blob/master/Doc/04-Commands_ja.md#ls--%E3%82%AA%E3%83%97%E3%82%B7%E3%83%A7%E3%83%B3-
>  -h -l 使用時に、人間が読みやすい形式でサイズを表記します (例:1K 234M 2G)

`ls -l` のファイルサイズ出力がカンマ区切りとなっています。
```
[C:/WorksLab/nyagos]
2020-07-05 01:31:10.41>ll
drwx---        0 Jul  5 01:18:45 Doc/
drwx---        0 Jul  5 01:18:45 Etc/
-rw-a--    1,542 Jul  5 01:18:45 LICENSE
-rw-a--      845 Jul  5 01:18:45 _nyagos
drwx---        0 Jul  5 01:18:45 alias/
-rw-a--    1,623 Jul  5 01:18:45 appveyor.yml
```

`humanize.Comma()` が使われていますが、単位表記にするためには `Bytes()` メソッドを使う必要があります。

/nyagos/commands/ls_windows.go:137
```go
    if (flag & O_HUMAN) != 0 {
        fmt.Fprintf(out, " %*s", width, humanize.Bytes(uint64(status.Size())))
    } else {
        fmt.Fprintf(out, " %*d", width, status.Size())
    }
```

```
<RYZEN3600X:C:/Workbench/nyagos>
$ ll
drwx---       0 B Jul  5 02:26:20 Doc/
drwx---       0 B Jul  5 02:29:04 Etc/
-rw-a--    1.5 kB Jul  5 02:26:20 LICENSE
-rw-a--     845 B Jul  5 02:26:20 _nyagos
drwx---       0 B Jul  5 02:26:20 alias/
-rw-a--    1.6 kB Jul  5 02:26:20 appveyor.yml
```

ただ、個人的にはカンマ区切りも好きです。
