### PR TITLE
fix: git subcommand completion for user extendable(like git br <branch>)

### DIFF
--- a/nyagos.d/catalog/git.lua
+++ b/nyagos.d/catalog/git.lua
@@ -118,7 +118,7 @@ if share.maincmds and share.maincmds["git"] then
         while #args > 2 and args[2]:sub(1,1) == "-" do
             table.remove(args,2)
         end
-        local t = gitsubcommands[subcmd]
+        local t = share.git.subcommand[subcmd]
         if type(t) == "function" then
             return t(args)
         elseif type(t) == "table" and #args == 2 then


### PR DESCRIPTION
Work below for user `.nyagos`

```lua:.nyagos
-- git
local gitsubcommands=share.git.subcommand
-- git subcommand alias
gitsubcommands["br"]=share.git.branch
share.git.subcommand=gitsubcommands
```

ex

```
$ git br <tab>
```