### PR TITLE
fix: subcomplete.lua some code and comment

### DIFF
--- a/nyagos.d/catalog/subcomplete.lua
+++ b/nyagos.d/catalog/subcomplete.lua
@@ -44,14 +44,20 @@ local function save_subcommands_cache(fname,list)
     fd:close()
 end
 
--- git
 
 local function update_cache()
+    -- git
     share.maincmds["git"] = load_subcommands_cache("git-subcommands.txt")
     share.maincmds["hub"] = load_subcommands_cache("hub-subcommands.txt")
     if not share.maincmds["git"] then
-        local githelp=io.popen("git help -a 2>nul","r")
-        local hubhelp=io.popen("hub help -a 2>nul","r")
+        local githelp
+        if nyagos.which("git.exe") then
+            githelp=io.popen("git help -a 2>nul","r")
+        end
+        local hubhelp
+        if nyagos.which("hub.exe") then
+            hubhelp=io.popen("hub help -a 2>nul","r")
+        end
         if githelp then
             local gitcmds={ "update-git-for-windows" }
             local hub=false
@@ -98,31 +104,29 @@ local function update_cache()
         end
     end
 
-    -- gh comand
+    -- gh command
     share.maincmds["gh"] = load_subcommands_cache("gh-subcommands.txt")
-    if not share.maincmds["gh"] then
-        if nyagos.which("gh.exe") then
-            local ghhelp=io.popen("gh -a 2>&1","r")
-            local ghcmds={}
-            for line in ghhelp:lines() do
-                local word = string.match(line,"^ +(%S+)")
-                if nil ~= word then
-                    ghcmds[ #ghcmds+1 ] = word
-                end
+    if (not share.maincmds["gh"]) and nyagos.which("gh.exe") then
+        local ghhelp=io.popen("gh -a 2>&1","r")
+        local ghcmds={}
+        for line in ghhelp:lines() do
+            local word = string.match(line,"^ +(%S+)")
+            if nil ~= word then
+                ghcmds[ #ghcmds+1 ] = word
             end
-            ghhelp:close()
-            if #ghcmds > 1 then
-                local maincmds = share.maincmds
-                maincmds["gh"] =  ghcmds
-                save_subcommands_cache("gh-subcommands.txt",ghcmds)
-                share.maincmds = maincmds
-            end
+        end
+        ghhelp:close()
+        if #ghcmds > 1 then
+            local maincmds = share.maincmds
+            maincmds["gh"] =  ghcmds
+            save_subcommands_cache("gh-subcommands.txt",ghcmds)
+            share.maincmds = maincmds
         end
     end
 
     -- Subversion
     share.maincmds["svn"] = load_subcommands_cache("svn-subcommands.txt")
-    if not share.maincmds["svn"] then
+    if (not share.maincmds["svn"]) and nyagos.which("svn.exe") then
         local svnhelp=nyagos.eval("svn help 2>nul","r")
         if string.len(svnhelp) > 5 then
             local svncmds={}
@@ -143,7 +147,7 @@ local function update_cache()
 
     -- Mercurial
     share.maincmds["hg"] = load_subcommands_cache("hg-subcommands.txt")
-    if not share.maincmds["hg"] then
+    if (not share.maincmds["hg"]) and nyagos.which("hg.exe") then
         local hghelp=nyagos.eval("hg debugcomplete 2>nul","r")
         if string.len(hghelp) > 5 then
             local hgcmds={}
@@ -162,9 +166,8 @@ local function update_cache()
     end
 
     -- Rclone
-
     share.maincmds["rclone"] = load_subcommands_cache("rclone-subcommands.txt")
-    if not share.maincmds["rclone"] then
+    if (not share.maincmds["rclone"]) and nyagos.which("rclone.exe") then
         local rclonehelp=io.popen("rclone --help 2>nul","r")
         if rclonehelp then
             local rclonecmds={}
@@ -196,8 +199,9 @@ local function update_cache()
         end
     end
 
+    -- fsutil command
     share.maincmds["fsutil"] = load_subcommands_cache("fsutil-subcommands.txt")
-    if not share.maincmds["fsutil"] then
+    if (not share.maincmds["fsutil"]) and nyagos.which("fsutil.exe") then
         local fd=io.popen("fsutil","r")
         if fd then
             local list = {}
@@ -215,6 +219,7 @@ local function update_cache()
         end
     end
 
+    -- golang
     share.maincmds["go"] = {
         "bug", "build", "clean", "doc", "env", "fix",
         "fmt", "generate", "get", "install", "list",
@@ -223,7 +228,7 @@ local function update_cache()
 
     -- scoop
     share.maincmds["scoop"] = load_subcommands_cache("scoop-subcommands.txt")
-    if not share.maincmds["scoop"] then
+    if (not share.maincmds["scoop"]) and nyagos.which("scoop.exe") then
         local fd=io.popen("scoop help", "r")
         if fd then
             local list = {}

--- a/nyagos.d/catalog/subcomplete.lua
+++ b/nyagos.d/catalog/subcomplete.lua
@@ -56,32 +56,32 @@ local function update_cache()
             local gitcmds={ "update-git-for-windows" }
             local hub=false
             if hubhelp then
-              hub=true
-              local startflag = false
-              local found=false
-              for line in hubhelp:lines() do
-                if not found then
-                  if startflag then
-                    -- skip blank line
-                    if string.match(line,"%S") then
-                      -- found commands
-                      for word in string.gmatch(line, "%S+") do
-                        gitcmds[ #gitcmds+1 ] = word
-                      end
-                      found = true
+                hub=true
+                local startflag = false
+                local found=false
+                for line in hubhelp:lines() do
+                    if not found then
+                        if startflag then
+                            -- skip blank line
+                            if string.match(line,"%S") then
+                                -- found commands
+                                for word in string.gmatch(line, "%S+") do
+                                    gitcmds[ #gitcmds+1 ] = word
+                                end
+                                found = true
+                            end
+                        end
+                        if string.match(line,"hub custom") then
+                            startflag = true
+                        end
                     end
-                  end
-                  if string.match(line,"hub custom") then
-                    startflag = true
-                  end
                 end
-              end
-              hubhelp:close()
+                hubhelp:close()
             end
             for line in githelp:lines() do
                 local word = string.match(line,"^ +(%S+)")
                 if nil ~= word then
-                  gitcmds[ #gitcmds+1 ] = word
+                    gitcmds[ #gitcmds+1 ] = word
                 end
             end
             githelp:close()
@@ -90,8 +90,8 @@ local function update_cache()
                 maincmds["git"] = gitcmds
                 save_subcommands_cache("git-subcommands.txt",gitcmds)
                 if hub then
-                  maincmds["hub"] = gitcmds
-                  save_subcommands_cache("hub-subcommands.txt",gitcmds)
+                    maincmds["hub"] = gitcmds
+                    save_subcommands_cache("hub-subcommands.txt",gitcmds)
                 end
                 share.maincmds = maincmds
             end
@@ -167,32 +167,32 @@ local function update_cache()
     if not share.maincmds["rclone"] then
         local rclonehelp=io.popen("rclone --help 2>nul","r")
         if rclonehelp then
-          local rclonecmds={}
-          local startflag = false
-          local flagsfound=false
-          for line in rclonehelp:lines() do
-              if not flagsfound then
-                  if string.match(line,"Available Commands:") then
-                    startflag = true
-                  end
-                  if string.match(line,"Flags:") then
-                      flagsfound = true
-                  end
-                  if startflag then
-                    local m=string.match(line,"^%s+([a-z]+)")
-                    if m then
-                        rclonecmds[ #rclonecmds+1 ] = m
+            local rclonecmds={}
+            local startflag = false
+            local flagsfound=false
+            for line in rclonehelp:lines() do
+                if not flagsfound then
+                    if string.match(line,"Available Commands:") then
+                        startflag = true
                     end
-                  end
-              end
-          end
-          rclonehelp:close()
-          if #rclonecmds > 1 then
-              local maincmds=share.maincmds
-              maincmds["rclone"] = rclonecmds
-              share.maincmds = maincmds
-              save_subcommands_cache("rclone-subcommands.txt",rclonecmds)
-          end
+                    if string.match(line,"Flags:") then
+                        flagsfound = true
+                    end
+                    if startflag then
+                        local m=string.match(line,"^%s+([a-z]+)")
+                        if m then
+                            rclonecmds[ #rclonecmds+1 ] = m
+                        end
+                    end
+                end
+            end
+            rclonehelp:close()
+            if #rclonecmds > 1 then
+                local maincmds=share.maincmds
+                maincmds["rclone"] = rclonecmds
+                share.maincmds = maincmds
+                save_subcommands_cache("rclone-subcommands.txt",rclonecmds)
+            end
         end
     end
 


### PR DESCRIPTION
This PR is fix below.

* comment string, position and lack.
* code indent adjust (space 4)
* command check add

At last, why is needed for command check?
When any command do not found, print for every shell starup 

```log
'scoop' is not recognized as an internal or external command,
operable program or batch file.
```

(ex "scoop")