### PR TITLE
feat: add fuzzyfinder catalog module

### DIFF
--- a/nyagos.d/catalog/fuzzyfinder.lua
+++ b/nyagos.d/catalog/fuzzyfinder.lua
@@ -1,0 +1,62 @@
+if not nyagos then
+    print("This is a script for nyagos not lua.exe")
+    os.exit()
+end
+
+share.fuzzyfinder         = share.fuzzyfinder or {}
+share.fuzzyfinder.cmd     = share.fuzzyfinder.cmd   or "fzf.exe"
+share.fuzzyfinder.args    = share.fuzzyfinder.args  or {}
+share.fuzzyfinder.args.dir     = share.fuzzyfinder.args.dir     or "--preview='dir {1}'"
+share.fuzzyfinder.args.cmdhist = share.fuzzyfinder.args.cmdhist or ""
+share.fuzzyfinder.args.cdhist  = share.fuzzyfinder.args.cdhist  or "--preview='dir {1}'"
+share.fuzzyfinder.args.gitlog  = share.fuzzyfinder.args.gitlog  or "--preview='git show {1} | cat'"
+
+nyagos.alias.dump_temp_out = function()
+    for _,val in ipairs(share.dump_temp_out) do
+        nyagos.write(val,"\n")
+    end
+end
+
+nyagos.bindkey("C-o",function(this)
+    local word,pos = this:lastword()
+    word = string.gsub(word,'"','')
+    share.dump_temp_out = nyagos.glob(word.."*")
+    local result=nyagos.eval('dump_temp_out | ' .. share.fuzzyfinder.cmd .. " " .. share.fuzzyfinder.args.dir)
+    this:call("CLEAR_SCREEN")
+    if string.find(result," ",1,true) then
+        result = '"'..result..'"'
+    end
+    assert( this:replacefrom(pos,result) )
+end)
+
+nyagos.alias.__dump_history = function()
+    local uniq={}
+    for i=nyagos.gethistory()-1,1,-1 do
+        local line = nyagos.gethistory(i)
+        if line ~= "" and not uniq[line] then
+            nyagos.write(line,"\n")
+            uniq[line] = true
+        end
+    end
+end
+
+nyagos.bindkey("C_R", function(this)
+    local result = nyagos.eval('__dump_history | ' .. share.fuzzyfinder.cmd .. " " .. share.fuzzyfinder.args.cmdhist)
+    this:call("CLEAR_SCREEN")
+    return result
+end)
+
+nyagos.bindkey("M_H" , function(this)
+    local result = nyagos.eval('cd --history | ' .. share.fuzzyfinder.cmd .. " " .. share.fuzzyfinder.args.cdhist)
+    this:call("CLEAR_SCREEN")
+    if string.find(result,' ') then
+        result = '"'..result..'"'
+    end
+    return result
+end)
+
+nyagos.bindkey("M_G" , function(this)
+    local result = nyagos.eval('git log --pretty="format:%h %s" | ' .. share.fuzzyfinder.cmd .. " " .. share.fuzzyfinder.args.gitlog)
+    this:call("CLEAR_SCREEN")
+    return string.match(result,"^%S+") or ""
+end)

--- a/nyagos.d/catalog/fuzzyfinder.lua
+++ b/nyagos.d/catalog/fuzzyfinder.lua
@@ -3,13 +3,22 @@ if not nyagos then
     os.exit()
 end
 
-share.fuzzyfinder         = share.fuzzyfinder or {}
-share.fuzzyfinder.cmd     = share.fuzzyfinder.cmd   or "fzf.exe"
-share.fuzzyfinder.args    = share.fuzzyfinder.args  or {}
-share.fuzzyfinder.args.dir     = share.fuzzyfinder.args.dir     or "--preview='dir {1}'"
+local fzf = {}
+fzf.cmd          =  "fzf.exe"
+fzf.args         =  {}
+fzf.args.dir     =  ""
+fzf.args.cmdhist =  ""
+fzf.args.cdhist  =  ""
+fzf.args.gitlog  =  "--preview='git show {1}'"
+
+share.fuzzyfinder = share.fuzzyfinder or fzf
+
+share.fuzzyfinder.cmd          = share.fuzzyfinder.cmd          or "fzf.exe"
+share.fuzzyfinder.args         = share.fuzzyfinder.args         or {}
+share.fuzzyfinder.args.dir     = share.fuzzyfinder.args.dir     or ""
 share.fuzzyfinder.args.cmdhist = share.fuzzyfinder.args.cmdhist or ""
-share.fuzzyfinder.args.cdhist  = share.fuzzyfinder.args.cdhist  or "--preview='dir {1}'"
-share.fuzzyfinder.args.gitlog  = share.fuzzyfinder.args.gitlog  or "--preview='git show {1} | cat'"
+share.fuzzyfinder.args.cdhist  = share.fuzzyfinder.args.cdhist  or ""
+share.fuzzyfinder.args.gitlog  = share.fuzzyfinder.args.gitlog  or ""
 
 nyagos.alias.dump_temp_out = function()
     for _,val in ipairs(share.dump_temp_out) do


### PR DESCRIPTION
# Proposal
Add catalog module for fuzzyfinder that bind to C_o/C_r/M_H/M_G .

Copy from "peco.lua", but generic module name and settings.

## Feature

- name is generic
- args add per selecting command

## Default value

Default settings use "fzf" and preview args.

- git log "git show {hash}"
- (dir item/cd hist "dir {target}" do not perfect work, removed)
 
When use "peco", set below:

- share.fuzzyfinder = {}
- share.fuzzyfinder.cmd  = "peco"
- share.fuzzyfinder.args = {}
- share.fuzzyfinder.args.dir     = ""
- share.fuzzyfinder.args.cmdhist = ""
- share.fuzzyfinder.args.cdhist  = ""
- share.fuzzyfinder.args.gitlog  = ""

## Backward compatibility

Keep "peco.lua" file, safe current setting code using peco user.

## Far future

I hope "peco.lua" integrate to "fuzzyfinder.lua".