### PR TITLE
Improve prediction

### DIFF
--- a/doc/release_note_en.md
+++ b/doc/release_note_en.md
@@ -8,6 +8,19 @@ Release notes
     - Regenerate with jj v0.35
     - Modify the generate script `make-complete-jj.lua` to output CRLF as line endings
 
+- Split the commit-prediction behavior that had been embedded in `FORWARD_CHAR` into three separate functions ([go-readline-ny#19], #476 and #477, thanks to @emisjerry):
+
+  - `FORWARD_CHAR`: move the cursor one character to the right
+  - `ACCEPT_PREDICT`: accept the current prediction
+  - `FORWARD_CHAR_OR_ACCEPT_PREDICT`: accept the prediction when the cursor is at the end of the line; otherwise move the cursor one character to the right
+
+  By default, the Right Arrow key and **Ctrl-F** are now bound to `FORWARD_CHAR_OR_ACCEPT_PREDICT`.
+
+- Made input prediction case-insensitive. ([go-readline-ny#20], #476 and #477, thanks to @emisjerry)
+
+[go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
+[go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
+
 4.4.18\_1
 ---------
 Nov 23, 2025

--- a/doc/release_note_ja.md
+++ b/doc/release_note_ja.md
@@ -8,6 +8,19 @@ Release notes
     - `jj` のサブコマンド補完をv0.35 ベースに更新
     - 改行コードが LF になっていたので、CRLF となるよう、生成スクリプト make-complete-jj.lua を修正
 
+- カーソル一文字分の右移動(`FORWARD_CHAR`)に組み込まれていた予測候補確定を分離し、次の3機能に分離した。([go-readline-ny#19], #476, #477, thanks to @emisjerry)
+
+  - 純粋にカーソル一文字分の右移動のみ (`FORWARD_CHAR`)
+  - 予測候補を確定 (`ACCEPT_PREDICT`)
+  - カーソルが行末の時は予測候補確定、さもなければカーソル一文字分移動(`FORWARD_CHAR_OR_ACCEPT_PREDICT`)
+
+  なお、右矢印キー、Ctrl-F はデフォルトで `FORWARD_CHAR_OR_ACCEPT_PREDICT` とした。
+
+- 入力予測機能で英大文字・小文字を区別しないようにした ([go-readline-ny#20], #476, #477, thanks to @emisjerry)
+
+[go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
+[go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
+
 4.4.18\_1
 ----------
 Nov 23, 2025

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/nyaosorg/glua-ole v0.0.0-20250402051125-b885836720e9
 	github.com/nyaosorg/go-box/v3 v3.0.0
 	github.com/nyaosorg/go-inline-animation v0.0.0-20210914120526-6dd4b5eefd20
-	github.com/nyaosorg/go-readline-ny v1.12.3
+	github.com/nyaosorg/go-readline-ny v1.13.0
 	github.com/nyaosorg/go-readline-skk v0.6.1
 	github.com/nyaosorg/go-ttyadapter v0.1.0
 	github.com/nyaosorg/go-windows-commandline v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/nyaosorg/go-box/v3 v3.0.0 h1:W5qfScEkKBoD68gbP/lwfWlvcTRB0rwXkhL+9iC6
 github.com/nyaosorg/go-box/v3 v3.0.0/go.mod h1:70GsE9mIh7JKVCxt71q3jEijO6C9YJmOZqWpPa9w+GY=
 github.com/nyaosorg/go-inline-animation v0.0.0-20210914120526-6dd4b5eefd20 h1:16XkjcdkjWTJX3jfFiP987ougN3RrK7oNr+rvau5INs=
 github.com/nyaosorg/go-inline-animation v0.0.0-20210914120526-6dd4b5eefd20/go.mod h1:r8i5fNh8CgCesa7wGRY1y9SNqSDpEyDIiRwNKtK0Sdc=
-github.com/nyaosorg/go-readline-ny v1.12.3 h1:nF+ywMS1XFpIeONssuUxmu20S2tQIqkq1ahdEXBhIYU=
-github.com/nyaosorg/go-readline-ny v1.12.3/go.mod h1:pFXLTklUi8JVi6gI3HdnA3Wak/7cl+kx2q8kIIiAf/c=
+github.com/nyaosorg/go-readline-ny v1.13.0 h1:3ifu0FQsswdB9N5vcph7lVzQvu20kVt6pMt1JuSz45o=
+github.com/nyaosorg/go-readline-ny v1.13.0/go.mod h1:pFXLTklUi8JVi6gI3HdnA3Wak/7cl+kx2q8kIIiAf/c=
 github.com/nyaosorg/go-readline-skk v0.6.1 h1:k8A50gJKb9WpDKEKHdXAZriOAWi8APJSZf07tPqb5ok=
 github.com/nyaosorg/go-readline-skk v0.6.1/go.mod h1:wjcWJkHorPQ2BepphQH33TbdAXcVmmYDeXZc4Y6dbzc=
 github.com/nyaosorg/go-ttyadapter v0.1.0 h1:3U3ytc35SOdkrn15rHLG36ozkmqBeGqhQgNufoep1AI=


### PR DESCRIPTION
## (English)

- Split the commit-prediction behavior that had been embedded in `FORWARD_CHAR` into three separate functions ([go-readline-ny#19] and [#476], thanks to @ emisjerry):

  - `FORWARD_CHAR`: move the cursor one character to the right
  - `ACCEPT_PREDICT`: accept the current prediction
  - `FORWARD_CHAR_OR_ACCEPT_PREDICT`: accept the prediction when the cursor is at the end of the line; otherwise move the cursor one character to the right

  By default, the Right Arrow key and **Ctrl-F** are now bound to `FORWARD_CHAR_OR_ACCEPT_PREDICT`.

- Made input prediction case-insensitive. ([go-readline-ny#20] and [#476], thanks to @ emisjerry)

## (Japanese)

- カーソル一文字分の右移動(`FORWARD_CHAR`)に組み込まれていた予測候補確定を分離し、次の3機能に分離した。([go-readline-ny#19] and [#476], thanks to emisjerry)

  - 純粋にカーソル一文字分の右移動のみ (`FORWARD_CHAR`)
  - 予測候補を確定 (`ACCEPT_PREDICT`)
  - カーソルが行末の時は予測候補確定、さもなければカーソル一文字分移動(`FORWARD_CHAR_OR_ACCEPT_PREDICT`)

  なお、右矢印キー、Ctrl-F はデフォルトで `FORWARD_CHAR_OR_ACCEPT_PREDICT` とした。

- 入力予測機能で英大文字・小文字を区別しないようにした ([go-readline-ny#20] and [#476], thanks to @ emisjerry)

[go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
[go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
[#476]: https://github.com/nyaosorg/nyagos/discussions/476