### PR TITLE
Lua scripts under the `nyagos.d` directory are now loaded automatically again

### DIFF
--- a/doc/release_note_en.md
+++ b/doc/release_note_en.md
@@ -18,6 +18,10 @@ Release notes
 
 - Made input prediction case-insensitive. ([go-readline-ny#20], #476 and #477, thanks to @emisjerry)
 
+- Lua scripts under the `nyagos.d` directory are now loaded automatically again. (#469, #478)
+  However, the standard scripts that used to reside in that directory remain embedded in the executable, and the default `nyagos.d` directory is empty.
+  ( Originally, the directory was not intended for user-defined scripts. )
+
 [go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
 [go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
 

--- a/doc/release_note_ja.md
+++ b/doc/release_note_ja.md
@@ -18,6 +18,10 @@ Release notes
 
 - 入力予測機能で英大文字・小文字を区別しないようにした ([go-readline-ny#20], #476, #477, thanks to @emisjerry)
 
+- nyagos.d 以下の Lua スクリプトを再び自動ロード対象とした。(#469, #478)
+  ただし、かつてあった nyagos.d 以下の標準スクリプトは引き続き EXE ファイル内に組み込みとし、デフォルトでは同フォルダー直下はファイルのない状態とする。
+  ( 当初は nyagos.d 配下にユーザが独自スクリプトを置く想定ではありませんでした )
+
 [go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
 [go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
 

--- a/internal/frame/loadscr.go
+++ b/internal/frame/loadscr.go
@@ -50,6 +50,12 @@ func LoadScripts(L scriptEngine, warn func(error) error) error {
 		exeName = os.Args[0]
 	}
 	exeFolder := filepath.Dir(exeName)
+	nyagosD := filepath.Join(exeFolder, "nyagos.d")
+	if _, err := os.Stat(nyagosD); err == nil {
+		if err := LoadScriptsFs(L, os.DirFS(nyagosD), warn); err != nil {
+			return err
+		}
+	}
 	if appDir, err := os.UserConfigDir(); err == nil {
 		dir := filepath.Join(appDir, "NYAOS_ORG/nyagos.d")
 		if _, err := os.Stat(dir); err != nil {


### PR DESCRIPTION
## ( English )

- This reverts commit 5af5771d1e2c79ce9d1e04106238bedfdc8820b7.
- Lua scripts under the `nyagos.d` directory are now loaded automatically again.
  However, the standard scripts that used to reside in that directory remain embedded in the executable, and the default `nyagos.d` directory is empty.
  ( Originally, the directory was not intended for user-defined scripts. )

## ( Japanese )

- この修正はコミット：  5af5771d1e2c79ce9d1e04106238bedfdc8820b7 を取り消すものです。
- nyagos.d 以下の Lua スクリプトを再び自動ロード対象とした。
  ただし、かつてあった nyagos.d 以下の標準スクリプトは引き続き EXE ファイル内に組み込みとし、デフォルトでは同フォルダー直下はファイルのない状態とする。
  ( 当初は nyagos.d 配下にユーザが独自スクリプトを置く想定ではありませんでした )