### PR TITLE
Do not stop processing other startup scripts when one of them fails

### DIFF
--- a/doc/release_note_en.md
+++ b/doc/release_note_en.md
@@ -22,6 +22,8 @@ Release notes
   However, the standard scripts that used to reside in that directory remain embedded in the executable, and the default `nyagos.d` directory is empty.
   ( Originally, the directory was not intended for user-defined scripts. )
 
+- Do not stop processing other startup scripts when one of them fails. (#479)
+
 [go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
 [go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
 

--- a/doc/release_note_ja.md
+++ b/doc/release_note_ja.md
@@ -22,6 +22,8 @@ Release notes
   ただし、かつてあった nyagos.d 以下の標準スクリプトは引き続き EXE ファイル内に組み込みとし、デフォルトでは同フォルダー直下はファイルのない状態とする。
   ( 当初は nyagos.d 配下にユーザが独自スクリプトを置く想定ではありませんでした )
 
+- 起動時に読み込むスクリプトのどれかでエラーが発生しても、残りのスクリプトの実行を続けるようにした。(#479)
+
 [go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
 [go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
 

--- a/internal/frame/loadscr.go
+++ b/internal/frame/loadscr.go
@@ -21,7 +21,7 @@ type scriptEngine interface {
 func LoadScriptsFs(L scriptEngine, fsys fs.FS, warn func(error) error) error {
 	entries, err := fs.ReadDir(fsys, ".")
 	if err != nil {
-		return err
+		return warn(err)
 	}
 	for _, entry1 := range entries {
 		if entry1.IsDir() {
@@ -33,7 +33,10 @@ func LoadScriptsFs(L scriptEngine, fsys fs.FS, warn func(error) error) error {
 		}
 		scriptCode, err := fs.ReadFile(fsys, scriptName)
 		if err != nil {
-			return err
+			if err = warn(err); err != nil {
+				return err
+			}
+			continue
 		}
 		if err := L.DoString(string(scriptCode)); err != nil {
 			if err = warn(fmt.Errorf("%s: %w", scriptName, err)); err != nil {


### PR DESCRIPTION
## English

- Do not stop processing other startup scripts when one of them fails.

## Japanese

- 起動時に読み込むスクリプトのどれかでエラーが発生しても、残りのスクリプトの実行を続けるようにした。