### PR TITLE
Add `nyagos.d/catalog/runall.lua`

### DIFF
--- a/doc/release_note_en.md
+++ b/doc/release_note_en.md
@@ -24,6 +24,12 @@ Release notes
 
 - Do not stop processing other startup scripts when one of them fails. (#479)
 
+- Added `runall.lua` to `nyagos.d/catalog`. This utility loads and executes all Lua scripts under the specified directories (#480). Example:
+  ```
+  local runall = require("runall")
+  runall("~/scriptdir1;~/scriptdir2")
+  ```
+
 [go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
 [go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
 

--- a/doc/release_note_ja.md
+++ b/doc/release_note_ja.md
@@ -24,6 +24,12 @@ Release notes
 
 - 起動時に読み込むスクリプトのどれかでエラーが発生しても、残りのスクリプトの実行を続けるようにした。(#479)
 
+- `runall.lua` スクリプトを `nyagos.d/catalog` に追加した。これは、指定ディレクトリ以下にあるすべての Lua スクリプトを順にロードして実行する (#480) 。使用例:
+  ```
+  local runall = require("runall")
+  runall("~/scriptdir1;~/scriptdir2")
+  ```
+
 [go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
 [go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
 

--- a/nyagos.d/catalog/runall.lua
+++ b/nyagos.d/catalog/runall.lua
@@ -1,0 +1,27 @@
+-- For example, on ~/.nyagos
+--   local runall = require("runall")
+--   runall(nyagos.env.NYAGOS_PRIVATE_DIRECTORIES)
+--
+--   require("runall")( nyagos.env.NYAGOS_PRIVATE_DIRECTORIES )
+
+return function(dirs)
+    for dir in string.gmatch(dirs,"[^;]+") do
+        if string.match(dir,"^%~[/\\]") then
+            dir = (nyagos.env.HOME or nyagos.env.USERPROFILE or "~") .. string.sub(dir,2)
+        end
+        local scripts = nyagos.glob(nyagos.pathjoin(dir,"*.lua"))
+        if scripts then
+            for i = 1, #scripts do
+                local chunk,err=loadfile(scripts[i])
+                if not chunk then
+                    io.stderr:write(scripts[i], ": ", err, "\n")
+                else
+                    local ok,err = pcall(chunk)
+                    if not ok then
+                        io.stderr:write(scripts[i], ": ", err, "\n")
+                    end
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
## English

- Added `runall.lua` to `nyagos.d/catalog`. This utility loads and executes all Lua scripts under the specified directories. Example:
  ```
  local runall = require("runall")
  runall("~/scriptdir1;~/scriptdir2")
  ```

## Japanese

- `runall.lua` スクリプトを `nyagos.d/catalog` に追加した。これは、指定ディレクトリ以下にあるすべての Lua スクリプトを順にロードして実行する。使用例:
  ```
  local runall = require("runall")
  runall("~/scriptdir1;~/scriptdir2")
  ```