### PR TITLE
Update go-readline-ny to v1.14.1

### DIFF
--- a/doc/release_note_en.md
+++ b/doc/release_note_en.md
@@ -30,6 +30,16 @@ Release notes
   runall("~/scriptdir1;~/scriptdir2")
   ```
 
+- Update go-readline-ny from v1.13.0 to [v1.14.1](https://github.com/nyaosorg/go-readline-ny/releases/tag/v1.14.1) and go-ttyadapter from v0.1.0 to [v0.3.0](https://github.com/nyaosorg/go-ttyadapter/releases/tag/v0.3.0) (#483)
+  - Changed the behavior of the Escape key to act as a prefix key instead of clearing input. This ensures that:
+    - Escape sequences such as `\x1B[A` (arrow keys) work correctly even when the input is split by the terminal.
+    - Pressing `Escape` is now equivalent to pressing `Alt`.
+  - `Esc`+`Left`  now behaves the same as `Esc`+`b` or `Alt`+`b`.
+  - `Esc`+`Right` now behaves the same as `Esc`+`f` or `Alt`+`f`.
+  - Changed the behavior of `Alt`+`f`, which previously moved the cursor to the beginning of the next word, to match GNU readline: it now moves to the end of the current or next word.
+  - `Alt`/`Esc`+`Backspace` and `ESC`+`Ctrl`+`w` now delete the word to the left of the cursor.
+  - `Alt`/`Esc`+`d` now deletes the current or next word.
+
 [go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
 [go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
 

--- a/doc/release_note_ja.md
+++ b/doc/release_note_ja.md
@@ -30,6 +30,16 @@ Release notes
   runall("~/scriptdir1;~/scriptdir2")
   ```
 
+- go-readline-ny をv1.13.0 から[v1.14.1](https://github.com/nyaosorg/go-readline-ny/releases/tag/v1.14.1) へ、go-ttyadapter を v0.1.0 から[v0.3.0](https://github.com/nyaosorg/go-ttyadapter/releases/tag/v0.3.0) へ更新 (#483)
+  - `Esc`キーの扱いを見直し、「入力内容のクリア」ではなくプリフィックスキーとして処理するように変更した。これにより
+    - 上矢印キーを表す `\x1B[A` などのキーシーケンスが端末の仕様により分割されて入力された場合でも、正しく動作するようになった。
+    - `Esc` の入力が `Alt` シフトと等価となった。
+  - `Esc`+`Left`  を `Esc`+`b`, `Alt`+`b` と等価にした。
+  - `Esc`+`Right` を `Esc`+`f`, `Alt`+`f` と等価にした。
+  - これまで次の単語の先頭への移動だった Alt + f の挙動を本家の readline に合わせ、現在または次の単語の末尾へ移動するように修正した。
+  - `Alt`/`Esc`+`Backspace`, `ESC`+`Ctrl`+`w` で、カーソル左の単語を削除するようにした。
+  - `Alt`+`d` で、カーソルから右直近の単語末尾までを削除するようにした。
+
 [go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
 [go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/nyaosorg/glua-ole v0.0.0-20250402051125-b885836720e9
 	github.com/nyaosorg/go-box/v3 v3.0.0
 	github.com/nyaosorg/go-inline-animation v0.0.0-20210914120526-6dd4b5eefd20
-	github.com/nyaosorg/go-readline-ny v1.13.0
+	github.com/nyaosorg/go-readline-ny v1.14.1
 	github.com/nyaosorg/go-readline-skk v0.6.1
 	github.com/nyaosorg/go-ttyadapter v0.3.0
 	github.com/nyaosorg/go-windows-commandline v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/nyaosorg/go-inline-animation v0.0.0-20210914120526-6dd4b5eefd20
 	github.com/nyaosorg/go-readline-ny v1.13.0
 	github.com/nyaosorg/go-readline-skk v0.6.1
-	github.com/nyaosorg/go-ttyadapter v0.1.0
+	github.com/nyaosorg/go-ttyadapter v0.3.0
 	github.com/nyaosorg/go-windows-commandline v0.1.0
 	github.com/nyaosorg/go-windows-consoleicon v0.0.0-20250402034108-1f245d5b597a
 	github.com/nyaosorg/go-windows-findfile v0.0.0-20250402044541-79e3d51e584d

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/nyaosorg/go-box/v3 v3.0.0 h1:W5qfScEkKBoD68gbP/lwfWlvcTRB0rwXkhL+9iC6
 github.com/nyaosorg/go-box/v3 v3.0.0/go.mod h1:70GsE9mIh7JKVCxt71q3jEijO6C9YJmOZqWpPa9w+GY=
 github.com/nyaosorg/go-inline-animation v0.0.0-20210914120526-6dd4b5eefd20 h1:16XkjcdkjWTJX3jfFiP987ougN3RrK7oNr+rvau5INs=
 github.com/nyaosorg/go-inline-animation v0.0.0-20210914120526-6dd4b5eefd20/go.mod h1:r8i5fNh8CgCesa7wGRY1y9SNqSDpEyDIiRwNKtK0Sdc=
-github.com/nyaosorg/go-readline-ny v1.13.0 h1:3ifu0FQsswdB9N5vcph7lVzQvu20kVt6pMt1JuSz45o=
-github.com/nyaosorg/go-readline-ny v1.13.0/go.mod h1:pFXLTklUi8JVi6gI3HdnA3Wak/7cl+kx2q8kIIiAf/c=
+github.com/nyaosorg/go-readline-ny v1.14.1 h1:bWyXpR6jRaCXysx4bnioxk36+YjQ6dypHKMjHnzIXdk=
+github.com/nyaosorg/go-readline-ny v1.14.1/go.mod h1:/BDf3/H/AScnvey4LoDws1bjTZDB76EE7uKnW2apoKU=
 github.com/nyaosorg/go-readline-skk v0.6.1 h1:k8A50gJKb9WpDKEKHdXAZriOAWi8APJSZf07tPqb5ok=
 github.com/nyaosorg/go-readline-skk v0.6.1/go.mod h1:wjcWJkHorPQ2BepphQH33TbdAXcVmmYDeXZc4Y6dbzc=
 github.com/nyaosorg/go-ttyadapter v0.3.0 h1:/Y7+rGJ0LEcs+AExevwNmND2VJvvpBmgbMuCbntKq3c=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/nyaosorg/go-readline-ny v1.13.0 h1:3ifu0FQsswdB9N5vcph7lVzQvu20kVt6pM
 github.com/nyaosorg/go-readline-ny v1.13.0/go.mod h1:pFXLTklUi8JVi6gI3HdnA3Wak/7cl+kx2q8kIIiAf/c=
 github.com/nyaosorg/go-readline-skk v0.6.1 h1:k8A50gJKb9WpDKEKHdXAZriOAWi8APJSZf07tPqb5ok=
 github.com/nyaosorg/go-readline-skk v0.6.1/go.mod h1:wjcWJkHorPQ2BepphQH33TbdAXcVmmYDeXZc4Y6dbzc=
-github.com/nyaosorg/go-ttyadapter v0.1.0 h1:3U3ytc35SOdkrn15rHLG36ozkmqBeGqhQgNufoep1AI=
-github.com/nyaosorg/go-ttyadapter v0.1.0/go.mod h1:w6ySb/Y8rpr0uIju4vN/TMRHC/6ayabORHmEVs6d/qE=
+github.com/nyaosorg/go-ttyadapter v0.3.0 h1:/Y7+rGJ0LEcs+AExevwNmND2VJvvpBmgbMuCbntKq3c=
+github.com/nyaosorg/go-ttyadapter v0.3.0/go.mod h1:w6ySb/Y8rpr0uIju4vN/TMRHC/6ayabORHmEVs6d/qE=
 github.com/nyaosorg/go-windows-commandline v0.1.0 h1:sQP8/iW4r8zdZSWW6lTNajEbxBi7twq47EJ6rjsY4oI=
 github.com/nyaosorg/go-windows-commandline v0.1.0/go.mod h1:u82aK0/yJBpmTGp8QYdNIbq+C8LdLp/tsgR4sOX3ohs=
 github.com/nyaosorg/go-windows-consoleicon v0.0.0-20250402034108-1f245d5b597a h1:71x0OsguXShN1AJCxhvF8mY3GXAY2NiGGOBb9UnuXOo=

--- a/internal/functions/builtinfunc.go
+++ b/internal/functions/builtinfunc.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mattn/go-tty"
 
 	"github.com/nyaosorg/go-box/v3"
-	"github.com/nyaosorg/go-ttyadapter/tty8"
+	"github.com/nyaosorg/go-ttyadapter/tty8pe"
 	"github.com/nyaosorg/go-windows-findfile"
 
 	"github.com/nyaosorg/nyagos/internal/completion"
@@ -113,7 +113,7 @@ func CmdGetKey(*Param) []any {
 }
 
 func CmdGetKeys(*Param) []any {
-	tty := &tty8.Tty{}
+	tty := &tty8pe.Tty{}
 	if err := tty.Open(nil); err != nil {
 		return []any{nil, err.Error()}
 	}


### PR DESCRIPTION
(English)
- Update go-readline-ny from v1.13.0 to [v1.14.1](https://github.com/nyaosorg/go-readline-ny/releases/tag/v1.14.1) and go-ttyadapter from v0.1.0 to [v0.3.0](https://github.com/nyaosorg/go-ttyadapter/releases/tag/v0.3.0)
  - Changed the behavior of the Escape key to act as a prefix key instead of clearing input. This ensures that:
    - Escape sequences such as `\x1B[A` (arrow keys) work correctly even when the input is split by the terminal.
    - Pressing `Escape` is now equivalent to pressing `Alt`.
  - `Esc`+`Left`  now behaves the same as `Esc`+`b` or `Alt`+`b`.
  - `Esc`+`Right` now behaves the same as `Esc`+`f` or `Alt`+`f`.
  - Changed the behavior of `Alt`+`f`, which previously moved the cursor to the beginning of the next word, to match GNU readline: it now moves to the end of the current or next word.
  - `Alt`/`Esc`+`Backspace` and `ESC`+`Ctrl`+`w` now delete the word to the left of the cursor.
  - `Alt`/`Esc`+`d` now deletes the current or next word.

(Japanese)
- go-readline-ny をv1.13.0 から[v1.14.1](https://github.com/nyaosorg/go-readline-ny/releases/tag/v1.14.1) へ、go-ttyadapter を v0.1.0 から[v0.3.0](https://github.com/nyaosorg/go-ttyadapter/releases/tag/v0.3.0) へ更新
  - `Esc`キーの扱いを見直し、「入力内容のクリア」ではなくプリフィックスキーとして処理するように変更した。これにより
    - 上矢印キーを表す `\x1B[A` などのキーシーケンスが端末の仕様により分割されて入力された場合でも、正しく動作するようになった。
    - `Esc` の入力が `Alt` シフトと等価となった。
  - `Esc`+`Left`  を `Esc`+`b`, `Alt`+`b` と等価にした。
  - `Esc`+`Right` を `Esc`+`f`, `Alt`+`f` と等価にした。
  - これまで次の単語の先頭への移動だった Alt + f の挙動を本家の readline に合わせ、現在または次の単語の末尾へ移動するように修正した。
  - `Alt`/`Esc`+`Backspace`, `ESC`+`Ctrl`+`w` で、カーソル左の単語を削除するようにした。
  - `Alt`+`d` で、カーソルから右直近の単語末尾までを削除するようにした。