### PR TITLE
`type`: Updated to match CMD.exe behavior, now requiring at least one argument (filename) (#489)

### DIFF
--- a/doc/release_note_en.md
+++ b/doc/release_note_en.md
@@ -40,6 +40,9 @@ Release notes
   - `Alt`/`Esc`+`Backspace` and `ESC`+`Ctrl`+`w` now delete the word to the left of the cursor.
   - `Alt`/`Esc`+`d` now deletes the current or next word.
 
+- Changed type command to require at least one argument, matching CMD.exe behavior. (#489,#490)  
+  (This avoids a race condition where a SIGINT from Ctrl-C could be delayed and incorrectly cancel the subsequent command.)
+
 [go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
 [go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
 

--- a/doc/release_note_ja.md
+++ b/doc/release_note_ja.md
@@ -40,6 +40,9 @@ Release notes
   - `Alt`/`Esc`+`Backspace`, `ESC`+`Ctrl`+`w` で、カーソル左の単語を削除するようにした。
   - `Alt`+`d` で、カーソルから右直近の単語末尾までを削除するようにした。
 
+- `type` コマンドの仕様を CMD.exe 同様、第一引数必須とした。 (#489,#490)  
+  (標準入力から読み取ると、Ctrl-C による SIGINT が遅延し、type ではなく、次のコマンドを中断させてしまうことが多いため)
+
 [go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
 [go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
 

--- a/internal/commands/type.go
+++ b/internal/commands/type.go
@@ -2,13 +2,13 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/nyaosorg/go-windows-mbcs"
-	"github.com/nyaosorg/nyagos/internal/nodos"
 )
 
 func cat(ctx context.Context, r io.Reader, w io.Writer) error {
@@ -33,37 +33,28 @@ func cat(ctx context.Context, r io.Reader, w io.Writer) error {
 }
 
 func cmdType(ctx context.Context, cmd Param) (int, error) {
-	if len(cmd.Args()) <= 1 {
-		if isTerminalIn(cmd.In()) {
-			c, err := nodos.EnableProcessInput()
-			if err != nil {
-				return 1, err
-			}
-			defer c()
-		}
-		if err := cat(ctx, cmd.In(), cmd.Out()); err != nil {
+	args := cmd.Args()
+	if len(args) <= 1 {
+		return 1, errors.New("The syntax of the command is incorrect.")
+	}
+	for _, arg1 := range args[1:] {
+		r, err := os.Open(arg1)
+		if err != nil {
 			return 1, err
 		}
-	} else {
-		for _, arg1 := range cmd.Args()[1:] {
-			r, err := os.Open(arg1)
-			if err != nil {
-				return 1, err
-			}
-			stat1, err := r.Stat()
-			if err != nil {
-				r.Close()
-				return 2, err
-			}
-			if stat1.IsDir() {
-				r.Close()
-				return 3, fmt.Errorf("%s: Permission denied", arg1)
-			}
-			err = cat(ctx, r, cmd.Out())
+		stat1, err := r.Stat()
+		if err != nil {
 			r.Close()
-			if err != nil {
-				return 0, err
-			}
+			return 2, err
+		}
+		if stat1.IsDir() {
+			r.Close()
+			return 3, fmt.Errorf("%s: Permission denied", arg1)
+		}
+		err = cat(ctx, r, cmd.Out())
+		r.Close()
+		if err != nil {
+			return 0, err
 		}
 	}
 	return 0, nil


### PR DESCRIPTION
(English)
- Changed type command to require at least one argument, matching CMD.exe behavior.  
  (This avoids a race condition where a SIGINT from Ctrl-C could be delayed and incorrectly cancel the subsequent command.)

(Japanese)
- `type` コマンドの仕様を CMD.exe 同様、第一引数必須とした。  
  (標準入力から読み取ると、Ctrl-C による SIGINT が遅延し、type ではなく、次のコマンドを中断させてしまうことが多いため)

See also #489 