### PR TITLE
Refactor and simplify the main shell loop

### DIFF
--- a/internal/shell/interpreter.go
+++ b/internal/shell/interpreter.go
@@ -417,8 +417,12 @@ type AlreadyReportedError struct {
 	Err error
 }
 
-func (AlreadyReportedError) Error() string {
-	return ""
+func (a AlreadyReportedError) Unwrap() error {
+	return a.Err
+}
+
+func (a AlreadyReportedError) Error() string {
+	return "AlreadyReportedError: " + a.Err.Error()
 }
 
 func isAlreadyReported(err error) bool {

--- a/internal/shell/interpreter_test.go
+++ b/internal/shell/interpreter_test.go
@@ -2,12 +2,27 @@ package shell_test
 
 import (
 	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/nyaosorg/nyagos/internal/shell"
 )
+
+func TestAlreadyReportedError(t *testing.T) {
+	a := shell.AlreadyReportedError{Err: io.EOF}
+
+	if !errors.Is(a, io.EOF) {
+		t.Fatal("AleadyReportedError failed to implement Unwrap():case 1")
+	}
+
+	b := shell.AlreadyReportedError{}
+	if errors.Is(b, io.EOF) {
+		t.Fatal("AleadyReportedError failed to implement Unwrap():case 2")
+	}
+}
 
 func TestInterpret(t *testing.T) {
 	ctx := context.Background()

--- a/internal/shell/loop.go
+++ b/internal/shell/loop.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -87,10 +88,10 @@ func (sh *Shell) Loop(ctx0 context.Context, stream Stream) (int, error) {
 		line, err := sh.ReadCommand(ctx)
 		if err != nil {
 			cancel()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return 0, err
 			}
-			if err == readline.CtrlC {
+			if errors.Is(err, readline.CtrlC) {
 				fmt.Fprintln(os.Stderr, err.Error())
 				continue
 			}
@@ -100,16 +101,12 @@ func (sh *Shell) Loop(ctx0 context.Context, stream Stream) (int, error) {
 		rc, err := sh.Interpret(ctx, line)
 
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				cancel()
 				return rc, err
 			}
-			if err1, ok := err.(AlreadyReportedError); ok {
-				if err1.Err == io.EOF {
-					cancel()
-					return rc, err
-				}
-			} else {
+			var e AlreadyReportedError
+			if !errors.As(err, &e) {
 				fmt.Fprintln(os.Stderr, err)
 			}
 		}

--- a/internal/shell/loop.go
+++ b/internal/shell/loop.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"runtime"
 	"syscall"
 
 	"github.com/nyaosorg/go-readline-ny"
@@ -74,18 +73,6 @@ func (sh *Shell) ReadCommand(ctx context.Context) (string, error) {
 	return line, nil
 }
 
-func dropSigint(sigint chan os.Signal) {
-	for {
-		select {
-		case <-sigint:
-			// println("drop sigint")
-			runtime.Gosched()
-		default:
-			return
-		}
-	}
-}
-
 // Loop executes commands from `stream` until any errors are found.
 func (sh *Shell) Loop(ctx0 context.Context, stream Stream) (int, error) {
 	backup := sh.Stream
@@ -94,34 +81,12 @@ func (sh *Shell) Loop(ctx0 context.Context, stream Stream) (int, error) {
 		sh.Stream = backup
 	}()
 
-	sigint := make(chan os.Signal, 1)
-	signal.Notify(sigint, os.Interrupt, syscall.SIGINT)
-
-	defer func() {
-		signal.Stop(sigint)
-		close(sigint)
-	}()
-
-	var cancel context.CancelFunc
-
-	go func() {
-		for range sigint {
-			if cancel != nil {
-				cancel()
-			}
-		}
-	}()
-
 	for {
-		dropSigint(sigint)
-
-		var ctx context.Context
-		ctx, cancel = context.WithCancel(ctx0)
+		ctx, cancel := signal.NotifyContext(ctx0, os.Interrupt, syscall.SIGINT)
 
 		line, err := sh.ReadCommand(ctx)
 		if err != nil {
 			cancel()
-			cancel = nil
 			if err == io.EOF {
 				return 0, err
 			}
@@ -152,7 +117,6 @@ func (sh *Shell) Loop(ctx0 context.Context, stream Stream) (int, error) {
 			fmt.Fprintf(os.Stderr, "exit status %d\n", rc)
 		}
 		cancel()
-		cancel = nil
 	}
 }
 


### PR DESCRIPTION
This PR simplifies the `(*Shell) Loop` implementation to improve maintainability and error handling.
(この PR は、保守性とエラーハンドリングを向上させるために `(*Shell) Loop` の実装を簡素化します。)

**Key Changes:**

1. **Signal Handling:** Replaced manual goroutine/channel management with `signal.NotifyContext` for more robust and idiomatic SIGINT handling.
2. **Error Handling:** Implemented `Unwrap()` for `AlreadyReportedError`, enabling clean error checks using `errors.Is`. This eliminates nested type assertions.