### PR TITLE
internal/mains: Pass context via Lua registry instead of `LState.SetContext`

### DIFF
--- a/doc/release_note_en.md
+++ b/doc/release_note_en.md
@@ -43,6 +43,8 @@ Release notes
 - Changed type command to require at least one argument, matching CMD.exe behavior. (#489,#490)  
   (This avoids a race condition where a SIGINT from Ctrl-C could be delayed and incorrectly cancel the subsequent command.)
 
+- Improved how Context is passed to Lua extensions. By using the Lua registry instead of `LState.SetContext`, we now suppress redundant Lua stack traces when a command is interrupted by Ctrl-C. (#492)
+
 [go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
 [go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
 

--- a/doc/release_note_ja.md
+++ b/doc/release_note_ja.md
@@ -43,6 +43,8 @@ Release notes
 - `type` コマンドの仕様を CMD.exe 同様、第一引数必須とした。 (#489,#490)  
   (標準入力から読み取ると、Ctrl-C による SIGINT が遅延し、type ではなく、次のコマンドを中断させてしまうことが多いため)
 
+- Lua 拡張関数への Context 渡しを LState 経由からレジストリ経由に変更した。これにより、Ctrl-C 中断時に Lua インタプリタが冗長なスタックトレースを表示する問題を解消した。(#492)
+
 [go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
 [go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
 

--- a/internal/mains/bindkey.go
+++ b/internal/mains/bindkey.go
@@ -62,7 +62,7 @@ func (rl *_ReadLineCallBack) evalKey(L Lua) int {
 		code = keys.Code(key)
 	}
 	function := rl.buffer.LookupCommand(string(code))
-	rc := function.Call(L.Context(), rl.buffer)
+	rc := function.Call(getContext(L), rl.buffer)
 	rl.buffer.RepaintLastLine()
 	switch rc {
 	case readline.ENTER:
@@ -82,7 +82,7 @@ func (rl *_ReadLineCallBack) KeyFunc(L Lua) int {
 	if err != nil {
 		return lerror(L, err.Error())
 	}
-	switch function.Call(L.Context(), rl.buffer) {
+	switch function.Call(getContext(L), rl.buffer) {
 	case readline.ENTER:
 		L.Push(lua.LTrue)
 	case readline.INTR:
@@ -179,7 +179,7 @@ func (f *_KeyLuaFunc) Call(ctx context.Context, buffer *readline.Buffer) readlin
 		L.SetField(table, "text", lua.LString(_text))
 	}
 
-	defer setContext(getContext(L), L)
+	defer clearContext(L)
 	setContext(ctx, L)
 
 	L.Push(table)

--- a/internal/mains/clone.go
+++ b/internal/mains/clone.go
@@ -54,9 +54,6 @@ func cloneTo(L1, L2 Lua) bool {
 			}
 		}
 	})
-	if ctx := L1.Context(); ctx != nil {
-		L2.SetContext(ctx)
-	}
 	return true
 }
 

--- a/internal/mains/complete.go
+++ b/internal/mains/complete.go
@@ -45,7 +45,7 @@ func (L *_LuaCallBack) luaHookForComplete(ctx context.Context, this *readline.Bu
 	L.SetField(tbl, "field", field)
 	L.SetField(tbl, "left", lua.LString(rv.Left))
 
-	defer setContext(getContext(L.Lua), L.Lua)
+	defer clearContext(L.Lua)
 	setContext(ctx, L.Lua)
 
 	L.Push(f)

--- a/internal/mains/complete4.go
+++ b/internal/mains/complete4.go
@@ -53,7 +53,7 @@ func (c *customCompleter) Complete(ctx context.Context, ua completion.UncComplet
 		LL.SetTable(tbl, lua.LNumber(i+1), lua.LString(arg1))
 	}
 
-	defer setContext(getContext(LL), LL)
+	defer clearContext(LL)
 	setContext(ctx, LL)
 
 	LL.Push(c.Func)

--- a/internal/mains/linefilter.go
+++ b/internal/mains/linefilter.go
@@ -32,7 +32,7 @@ func luaLineFilter(ctx context.Context, L Lua, line string) string {
 
 	L.Push(luaFilter)
 	L.Push(lua.LString(line))
-	defer setContext(getContext(L), L)
+	defer clearContext(L)
 	setContext(ctx, L)
 	err := L.PCall(1, 1, nil)
 	if err != nil {

--- a/internal/mains/lua.go
+++ b/internal/mains/lua.go
@@ -546,7 +546,7 @@ func luaRedirect(ctx context.Context, _stdin, _stdout, _stderr *os.File, L Lua, 
 }
 
 func execLuaKeepContextAndShell(ctx context.Context, sh *shell.Shell, L Lua, nargs, nresult int) error {
-	defer setContext(getContext(L), L)
+	defer clearContext(L)
 	setContext(ctx, L)
 	restore := pushLuaRegistry(L, shellLuaRegistryKey, sh)
 	defer restore()

--- a/internal/mains/luareg.go
+++ b/internal/mains/luareg.go
@@ -9,6 +9,7 @@ import (
 const (
 	readlineLuaRegistryKey = "nyagos.readline"
 	shellLuaRegistryKey    = "nyagos.shell"
+	ctxLuaRegistryKey      = "nyagos.context"
 )
 
 func getLuaRegistry(L Lua, key string) any {
@@ -37,6 +38,14 @@ func setLuaRegistry(L Lua, key string, value any) {
 	}
 }
 
+func clearLuaRegistry(L Lua, key string) {
+	reg, ok := L.Get(lua.RegistryIndex).(*lua.LTable)
+	if !ok {
+		return
+	}
+	L.SetField(reg, key, lua.LNil)
+}
+
 func pushLuaRegistry(L Lua, key string, value any) func() {
 	orig := getLuaRegistry(L, key)
 	setLuaRegistry(L, key, value)
@@ -49,9 +58,16 @@ func setContext(ctx context.Context, L Lua) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	L.SetContext(ctx)
+	setLuaRegistry(L, ctxLuaRegistryKey, ctx)
+}
+
+func clearContext(L Lua) {
+	clearLuaRegistry(L, ctxLuaRegistryKey)
 }
 
 func getContext(L Lua) context.Context {
-	return L.Context()
+	if v, ok := getLuaRegistry(L, ctxLuaRegistryKey).(context.Context); ok {
+		return v
+	}
+	return context.Background()
 }

--- a/internal/mains/nyagos.go
+++ b/internal/mains/nyagos.go
@@ -73,7 +73,7 @@ func (*_ScriptEngineForOptionImpl) RunFile(ctx context.Context, fname string) ([
 	if !ok {
 		return nil, errors.New("script is not supported")
 	}
-	defer setContext(getContext(L), L)
+	defer clearContext(L)
 	setContext(ctx, L)
 	return nil, luaRedirect(ctx, os.Stdin, os.Stdout, os.Stderr, L, func() error {
 		return doFileExceptAtMarkLines(L, fname)
@@ -85,7 +85,7 @@ func (impl *_ScriptEngineForOptionImpl) RunString(ctx context.Context, code stri
 	if !ok {
 		return errors.New("script is not supported")
 	}
-	defer setContext(getContext(L), L)
+	defer clearContext(L)
 	setContext(ctx, L)
 	restore := pushLuaRegistry(L, shellLuaRegistryKey, impl.Sh)
 	defer restore()
@@ -138,7 +138,7 @@ func Run(fsys fs.FS) error {
 	defer sh.Close()
 	sh.Console = colorable.NewColorableStdout()
 
-	defer setContext(getContext(L), L)
+	defer clearContext(L)
 	setContext(ctx, L)
 	restore := pushLuaRegistry(L, shellLuaRegistryKey, sh)
 	defer restore()


### PR DESCRIPTION
(English)
- Improved how Context is passed to Lua extensions. By using the Lua registry instead of `LState.SetContext`, we now suppress redundant Lua stack traces when a command is interrupted by Ctrl-C.

(Japanese)
- Lua 拡張関数への Context 渡しを LState 経由からレジストリ経由に変更した。これにより、Ctrl-C 中断時に Lua インタプリタが冗長なスタックトレースを表示する問題を解消した。
