### PR TITLE
Fixed an issue where the version string was empty when built without GNU Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,17 @@ dist:
 	$(SET) "GOOS=windows" && $(SET) "GOARCH=amd64" && $(MAKE) _dist "FILES=makeicon.cmd"
 	$(SET) "GOOS=linux"   && $(SET) "GOARCH=amd64" && $(MAKE) _dist
 
+LATEST=$(GO) run github.com/hymkor/latest-notes@latest -pattern "^\d+\.\d+\.\d+\\?\_\d+$$"
+NOTES=doc/release_note_*.md
+
 release:
-	$(GO) run github.com/hymkor/latest-notes@latest -pattern "^\d+\.\d+\.\d+\\?\_\d+$" doc/release_note_*.md | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
+	$(LATEST) $(NOTES) | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
+
+dry-release:
+	$(LATEST) $(NOTES)
+
+bump:
+	$(LATEST) -gosrc main -suffix "-goinstall" $(NOTES) > version.go
 
 $(SUPPORTGO):
 	go install golang.org/dl/$(SUPPORTGO)@latest

--- a/doc/release_note_en.md
+++ b/doc/release_note_en.md
@@ -45,6 +45,9 @@ Release notes
 
 - Improved how Context is passed to Lua extensions. By using the Lua registry instead of `LState.SetContext`, we now suppress redundant Lua stack traces when a command is interrupted by Ctrl-C. (#492)
 
+- Fixed an issue where the version string was empty when built without GNU Make.
+  The version string is now updated via `make bump` during the release process. (#493)
+
 [go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
 [go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
 

--- a/doc/release_note_ja.md
+++ b/doc/release_note_ja.md
@@ -45,6 +45,9 @@ Release notes
 
 - Lua 拡張関数への Context 渡しを LState 経由からレジストリ経由に変更した。これにより、Ctrl-C 中断時に Lua インタプリタが冗長なスタックトレースを表示する問題を解消した。(#492)
 
+- GNU Make なしでビルドした場合に、バージョン文字列が空になってしまう問題を修正
+今後、バージョンアップ時に `make bump` を実行する (#493)
+
 [go-readline-ny#19]: https://github.com/nyaosorg/go-readline-ny/pull/19
 [go-readline-ny#20]: https://github.com/nyaosorg/go-readline-ny/pull/20
 

--- a/main.go
+++ b/main.go
@@ -12,8 +12,6 @@ import (
 	"github.com/nyaosorg/nyagos/internal/onexit"
 )
 
-var version = "snapshot"
-
 //go:embed embed/*.lua
 var embedLua embed.FS
 

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package main
+
+var version = "4.4.18_1-goinstall"


### PR DESCRIPTION
(English)
- Fixed an issue where the version string was empty when built without GNU Make.
  The version string is now updated via `make bump` during the release process.

(Japanese)
- GNU Make なしでビルドした場合に、バージョン文字列が空になってしまう問題を修正
  今後、バージョンアップ時に `make bump` を実行する