### PR TITLE
nyagos.d/catalog/complete-jj.lua: Update jj version to v0.39.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,4 +83,7 @@ $(SUPPORTGO):
 	go install golang.org/dl/$(SUPPORTGO)@latest
 	"$(shell go env GOPATH)/bin/$(SUPPORTGO)" download
 
+update-complete-jj:
+	cd "nyagos.d/catalog" && "../../nyagos" -f make-complete-jj.lua
+
 .PHONY: build debug test tstlua clean get _dist dist release install docs

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -29,9 +29,10 @@ Changelog
 
 - Implemented `nyagos.setnextline(STR)`, which sets the initial text for the next readline prompt. (#458, #466, thanks to @emisjerry)
 
-- `nyagos.d/catalog/complete-jj.lua` (#473, #474, Thanks to @tsuyoshicho)
-    - Regenerate with jj v0.35
+- `nyagos.d/catalog/complete-jj.lua` (#473, #474, #499, Thanks to @tsuyoshicho)
+    - Regenerate with jj v0.39
     - Modify the generate script `make-complete-jj.lua` to output CRLF as line endings
+    - Enable `make update-complete-jj` to update complete-jj.lua
 
 - Split the commit-prediction behavior that had been embedded in `FORWARD_CHAR` into three separate functions ([go-readline-ny#19], #476 and #477, thanks to @emisjerry):
 

--- a/doc/CHANGELOG_ja.md
+++ b/doc/CHANGELOG_ja.md
@@ -29,9 +29,10 @@ Changelog
 
 - readline の次回プロンプトに挿入する初期テキストを設定する `nyagos.setnextline(STR)` を実装 (#458, #466, thanks to @emisjerry)
 
-- `nyagos.d/catalog/complete-jj.lua` (#473, #474, Thanks to @tsuyoshicho)
-    - `jj` のサブコマンド補完をv0.35 ベースに更新
+- `nyagos.d/catalog/complete-jj.lua` (#473, #474, #499, Thanks to @tsuyoshicho)
+    - `jj` のサブコマンド補完をv0.39 ベースに更新
     - 改行コードが LF になっていたので、CRLF となるよう、生成スクリプト make-complete-jj.lua を修正
+    - `make update-complete-jj` から complete-jj.lua を更新できるようにした
 
 - カーソル一文字分の右移動(`FORWARD_CHAR`)に組み込まれていた予測候補確定を分離し、次の3機能に分離した。([go-readline-ny#19], #476, #477, thanks to @emisjerry)
 

--- a/nyagos.d/catalog/complete-jj.lua
+++ b/nyagos.d/catalog/complete-jj.lua
@@ -1,10 +1,12 @@
 share.jj={
     ["abandon"]={},
     ["absorb"]={},
+    ["arrange"]={},
     ["bisect"]={
         ["run"]={},
     },
     ["bookmark"]={
+        ["advance"]={},
         ["create"]={},
         ["delete"]={},
         ["forget"]={},
@@ -34,6 +36,7 @@ share.jj={
         ["annotate"]={},
         ["chmod"]={},
         ["list"]={},
+        ["search"]={},
         ["show"]={},
         ["track"]={},
         ["untrack"]={},
@@ -62,6 +65,7 @@ share.jj={
     ["operation"]={
         ["abandon"]={},
         ["diff"]={},
+        ["integrate"]={},
         ["log"]={},
         ["restore"]={},
         ["revert"]={},
@@ -101,6 +105,7 @@ share.jj={
         ["gc"]={},
         ["install-man-pages"]={},
         ["markdown-help"]={},
+        ["snapshot"]={},
     },
     ["version"]={},
     ["workspace"]={


### PR DESCRIPTION
(English)
-  Regenerate with [jj v0.39]
- Enable `make update-complete-jj` to update complete-jj.lua

(Japanese)
- jj のサブコマンド補完を [v0.39][jj v0.39] ベースに更新
- `make update-complete-jj` から complete-jj.lua を更新できるようにした

[jj v0.39]: https://github.com/jj-vcs/jj/releases/tag/v0.39.0